### PR TITLE
Add EQUIPMENT_DATA JSON and TypeScript types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2947,6 +2947,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/src/data/equipment.json
+++ b/src/data/equipment.json
@@ -1,0 +1,11855 @@
+{
+  "weaponTiers": [
+    {
+      "tier": 1,
+      "name": "Common",
+      "color": "#9E9E9E",
+      "baseDamage": 50,
+      "damagePerLevel": 2,
+      "baseHp": 500,
+      "hpPerLevel": 10,
+      "craftCost": 500,
+      "tierMultiplier": 1
+    },
+    {
+      "tier": 2,
+      "name": "Uncommon",
+      "color": "#4CAF50",
+      "baseDamage": 150,
+      "damagePerLevel": 6,
+      "baseHp": 1500,
+      "hpPerLevel": 30,
+      "craftCost": 2500,
+      "tierMultiplier": 1.2
+    },
+    {
+      "tier": 3,
+      "name": "Rare",
+      "color": "#2196F3",
+      "baseDamage": 400,
+      "damagePerLevel": 16,
+      "baseHp": 4000,
+      "hpPerLevel": 80,
+      "craftCost": 10000,
+      "tierMultiplier": 1.5
+    },
+    {
+      "tier": 4,
+      "name": "Epic",
+      "color": "#9C27B0",
+      "baseDamage": 1000,
+      "damagePerLevel": 40,
+      "baseHp": 10000,
+      "hpPerLevel": 200,
+      "craftCost": 50000,
+      "tierMultiplier": 2
+    },
+    {
+      "tier": 5,
+      "name": "Legendary",
+      "color": "#FF9800",
+      "baseDamage": 3000,
+      "damagePerLevel": 120,
+      "baseHp": 30000,
+      "hpPerLevel": 600,
+      "craftCost": 250000,
+      "tierMultiplier": 3
+    },
+    {
+      "tier": 6,
+      "name": "Mythic",
+      "color": "#F44336",
+      "baseDamage": 10000,
+      "damagePerLevel": 400,
+      "baseHp": 100000,
+      "hpPerLevel": 2000,
+      "craftCost": 1500000,
+      "tierMultiplier": 5
+    },
+    {
+      "tier": 7,
+      "name": "Transcendent",
+      "color": "#FFD700",
+      "baseDamage": 40000,
+      "damagePerLevel": 1600,
+      "baseHp": 400000,
+      "hpPerLevel": 8000,
+      "craftCost": 10000000,
+      "tierMultiplier": 10
+    }
+  ],
+  "soulWeapons": [
+    {
+      "id": "fire_blade",
+      "name": "Inferno Blade",
+      "element": "Fire",
+      "tier": "Epic",
+      "baseDamage": 1200,
+      "critRateBonus": 3,
+      "critDmgBonus": 15,
+      "elementBonus": 20,
+      "specialEffect": "Burn: 10% chance to inflict Burn dealing 5% ATK/s for 3s",
+      "acquisitionMethod": "Soul Dungeon Stage 30"
+    },
+    {
+      "id": "fire_greatsword",
+      "name": "Volcanic Greatsword",
+      "element": "Fire",
+      "tier": "Legendary",
+      "baseDamage": 4500,
+      "critRateBonus": 5,
+      "critDmgBonus": 25,
+      "elementBonus": 30,
+      "specialEffect": "Eruption: kills trigger AoE burst dealing 150% ATK",
+      "acquisitionMethod": "Soul Dungeon Stage 70"
+    },
+    {
+      "id": "water_trident",
+      "name": "Tidal Trident",
+      "element": "Water",
+      "tier": "Epic",
+      "baseDamage": 1100,
+      "critRateBonus": 2,
+      "critDmgBonus": 12,
+      "elementBonus": 18,
+      "specialEffect": "Freeze: 8% chance to freeze enemy for 2s",
+      "acquisitionMethod": "Soul Dungeon Stage 35"
+    },
+    {
+      "id": "water_bow",
+      "name": "Abyssal Bow",
+      "element": "Water",
+      "tier": "Legendary",
+      "baseDamage": 4200,
+      "critRateBonus": 6,
+      "critDmgBonus": 20,
+      "elementBonus": 28,
+      "specialEffect": "Torrent: every 5th shot deals 200% ATK to all enemies",
+      "acquisitionMethod": "Soul Dungeon Stage 75"
+    },
+    {
+      "id": "earth_hammer",
+      "name": "Granite Hammer",
+      "element": "Earth",
+      "tier": "Epic",
+      "baseDamage": 1400,
+      "critRateBonus": 1,
+      "critDmgBonus": 10,
+      "elementBonus": 22,
+      "specialEffect": "Quake: attacks have 12% chance to stun for 1.5s",
+      "acquisitionMethod": "Soul Dungeon Stage 40"
+    },
+    {
+      "id": "earth_axe",
+      "name": "Tectonic Axe",
+      "element": "Earth",
+      "tier": "Legendary",
+      "baseDamage": 5200,
+      "critRateBonus": 3,
+      "critDmgBonus": 18,
+      "elementBonus": 32,
+      "specialEffect": "Landslide: every kill reduces cooldowns by 1s",
+      "acquisitionMethod": "Soul Dungeon Stage 80"
+    },
+    {
+      "id": "wind_daggers",
+      "name": "Gale Daggers",
+      "element": "Wind",
+      "tier": "Epic",
+      "baseDamage": 950,
+      "critRateBonus": 7,
+      "critDmgBonus": 20,
+      "elementBonus": 16,
+      "specialEffect": "Slipstream: +20% movement speed, +5% dodge",
+      "acquisitionMethod": "Soul Dungeon Stage 45"
+    },
+    {
+      "id": "wind_scythe",
+      "name": "Cyclone Scythe",
+      "element": "Wind",
+      "tier": "Legendary",
+      "baseDamage": 3800,
+      "critRateBonus": 10,
+      "critDmgBonus": 30,
+      "elementBonus": 25,
+      "specialEffect": "Whirlwind: attacks hit all enemies in a 2m radius",
+      "acquisitionMethod": "Soul Dungeon Stage 85"
+    },
+    {
+      "id": "light_sword",
+      "name": "Radiant Sword",
+      "element": "Light",
+      "tier": "Legendary",
+      "baseDamage": 4800,
+      "critRateBonus": 8,
+      "critDmgBonus": 22,
+      "elementBonus": 28,
+      "specialEffect": "Holy Smite: +15% dmg vs Dark enemies; heals 2% max HP/kill",
+      "acquisitionMethod": "Soul Dungeon Stage 90"
+    },
+    {
+      "id": "light_spear",
+      "name": "Divine Spear",
+      "element": "Light",
+      "tier": "Mythic",
+      "baseDamage": 12000,
+      "critRateBonus": 12,
+      "critDmgBonus": 35,
+      "elementBonus": 40,
+      "specialEffect": "Judgement: 15% chance to instantly slay enemy below 20% HP",
+      "acquisitionMethod": "Soul Dungeon Stage 120"
+    },
+    {
+      "id": "dark_staff",
+      "name": "Void Staff",
+      "element": "Dark",
+      "tier": "Legendary",
+      "baseDamage": 5500,
+      "critRateBonus": 4,
+      "critDmgBonus": 28,
+      "elementBonus": 30,
+      "specialEffect": "Curse: reduce enemy DEF by 20% for 5s on hit",
+      "acquisitionMethod": "Soul Dungeon Stage 95"
+    },
+    {
+      "id": "dark_scythe",
+      "name": "Reaper Scythe",
+      "element": "Dark",
+      "tier": "Mythic",
+      "baseDamage": 14000,
+      "critRateBonus": 6,
+      "critDmgBonus": 40,
+      "elementBonus": 42,
+      "specialEffect": "Soul Drain: 20% of damage dealt restores HP",
+      "acquisitionMethod": "Soul Dungeon Stage 130"
+    }
+  ],
+  "accessories": [
+    {
+      "id": "ring_atk_common",
+      "name": "Iron Ring",
+      "slot": "Ring",
+      "tier": "Common",
+      "bonusType": "ATK",
+      "bonusValue": 50,
+      "isPercent": false,
+      "craftCost": 300
+    },
+    {
+      "id": "ring_atk_uncommon",
+      "name": "Steel Ring",
+      "slot": "Ring",
+      "tier": "Uncommon",
+      "bonusType": "ATK",
+      "bonusValue": 150,
+      "isPercent": false,
+      "craftCost": 1500
+    },
+    {
+      "id": "ring_atk_rare",
+      "name": "Silver Ring",
+      "slot": "Ring",
+      "tier": "Rare",
+      "bonusType": "ATK",
+      "bonusValue": 400,
+      "isPercent": false,
+      "craftCost": 7500
+    },
+    {
+      "id": "ring_atk_epic",
+      "name": "Platinum Ring",
+      "slot": "Ring",
+      "tier": "Epic",
+      "bonusType": "ATK",
+      "bonusValue": 1000,
+      "isPercent": false,
+      "craftCost": 40000
+    },
+    {
+      "id": "ring_atk_legendary",
+      "name": "Dragon Ring",
+      "slot": "Ring",
+      "tier": "Legendary",
+      "bonusType": "ATK",
+      "bonusValue": 5,
+      "isPercent": true,
+      "craftCost": 200000
+    },
+    {
+      "id": "ring_atk_mythic",
+      "name": "Godslayer Ring",
+      "slot": "Ring",
+      "tier": "Mythic",
+      "bonusType": "ATK",
+      "bonusValue": 12,
+      "isPercent": true,
+      "craftCost": 1200000
+    },
+    {
+      "id": "ring_crit_rare",
+      "name": "Sharpened Ring",
+      "slot": "Ring",
+      "tier": "Rare",
+      "bonusType": "Crit%",
+      "bonusValue": 2,
+      "isPercent": true,
+      "craftCost": 8000
+    },
+    {
+      "id": "ring_crit_epic",
+      "name": "Sniper Ring",
+      "slot": "Ring",
+      "tier": "Epic",
+      "bonusType": "Crit%",
+      "bonusValue": 4,
+      "isPercent": true,
+      "craftCost": 45000
+    },
+    {
+      "id": "ring_crit_legendary",
+      "name": "Assassin Ring",
+      "slot": "Ring",
+      "tier": "Legendary",
+      "bonusType": "Crit%",
+      "bonusValue": 7,
+      "isPercent": true,
+      "craftCost": 220000
+    },
+    {
+      "id": "neck_hp_common",
+      "name": "Leather Cord",
+      "slot": "Necklace",
+      "tier": "Common",
+      "bonusType": "HP",
+      "bonusValue": 500,
+      "isPercent": false,
+      "craftCost": 350
+    },
+    {
+      "id": "neck_hp_uncommon",
+      "name": "Bronze Necklace",
+      "slot": "Necklace",
+      "tier": "Uncommon",
+      "bonusType": "HP",
+      "bonusValue": 1500,
+      "isPercent": false,
+      "craftCost": 1800
+    },
+    {
+      "id": "neck_hp_rare",
+      "name": "Sapphire Necklace",
+      "slot": "Necklace",
+      "tier": "Rare",
+      "bonusType": "HP",
+      "bonusValue": 4000,
+      "isPercent": false,
+      "craftCost": 9000
+    },
+    {
+      "id": "neck_hp_epic",
+      "name": "Void Necklace",
+      "slot": "Necklace",
+      "tier": "Epic",
+      "bonusType": "HP",
+      "bonusValue": 12000,
+      "isPercent": false,
+      "craftCost": 48000
+    },
+    {
+      "id": "neck_hp_legendary",
+      "name": "Dragon Heart Chain",
+      "slot": "Necklace",
+      "tier": "Legendary",
+      "bonusType": "HP",
+      "bonusValue": 8,
+      "isPercent": true,
+      "craftCost": 240000
+    },
+    {
+      "id": "neck_hp_mythic",
+      "name": "Eternal Life Chain",
+      "slot": "Necklace",
+      "tier": "Mythic",
+      "bonusType": "HP",
+      "bonusValue": 18,
+      "isPercent": true,
+      "craftCost": 1400000
+    },
+    {
+      "id": "neck_gold_rare",
+      "name": "Gold Chain",
+      "slot": "Necklace",
+      "tier": "Rare",
+      "bonusType": "Gold",
+      "bonusValue": 5,
+      "isPercent": true,
+      "craftCost": 10000
+    },
+    {
+      "id": "neck_gold_epic",
+      "name": "Midas Chain",
+      "slot": "Necklace",
+      "tier": "Epic",
+      "bonusType": "Gold",
+      "bonusValue": 10,
+      "isPercent": true,
+      "craftCost": 55000
+    },
+    {
+      "id": "neck_gold_legendary",
+      "name": "Fortune Chain",
+      "slot": "Necklace",
+      "tier": "Legendary",
+      "bonusType": "Gold",
+      "bonusValue": 20,
+      "isPercent": true,
+      "craftCost": 280000
+    },
+    {
+      "id": "neck_exp_epic",
+      "name": "Scholar Necklace",
+      "slot": "Necklace",
+      "tier": "Epic",
+      "bonusType": "EXP",
+      "bonusValue": 10,
+      "isPercent": true,
+      "craftCost": 52000
+    },
+    {
+      "id": "neck_exp_legendary",
+      "name": "Sage Necklace",
+      "slot": "Necklace",
+      "tier": "Legendary",
+      "bonusType": "EXP",
+      "bonusValue": 20,
+      "isPercent": true,
+      "craftCost": 260000
+    },
+    {
+      "id": "belt_def_common",
+      "name": "Rope Belt",
+      "slot": "Belt",
+      "tier": "Common",
+      "bonusType": "DEF",
+      "bonusValue": 30,
+      "isPercent": false,
+      "craftCost": 400
+    },
+    {
+      "id": "belt_def_uncommon",
+      "name": "Leather Belt",
+      "slot": "Belt",
+      "tier": "Uncommon",
+      "bonusType": "DEF",
+      "bonusValue": 100,
+      "isPercent": false,
+      "craftCost": 2000
+    },
+    {
+      "id": "belt_def_rare",
+      "name": "Chain Belt",
+      "slot": "Belt",
+      "tier": "Rare",
+      "bonusType": "DEF",
+      "bonusValue": 280,
+      "isPercent": false,
+      "craftCost": 9500
+    },
+    {
+      "id": "belt_def_epic",
+      "name": "Plate Belt",
+      "slot": "Belt",
+      "tier": "Epic",
+      "bonusType": "DEF",
+      "bonusValue": 800,
+      "isPercent": false,
+      "craftCost": 50000
+    },
+    {
+      "id": "belt_def_legendary",
+      "name": "Guardian Belt",
+      "slot": "Belt",
+      "tier": "Legendary",
+      "bonusType": "DEF",
+      "bonusValue": 6,
+      "isPercent": true,
+      "craftCost": 250000
+    },
+    {
+      "id": "belt_def_mythic",
+      "name": "Fortress Belt",
+      "slot": "Belt",
+      "tier": "Mythic",
+      "bonusType": "DEF",
+      "bonusValue": 15,
+      "isPercent": true,
+      "craftCost": 1500000
+    },
+    {
+      "id": "ear_critdmg_uncommon",
+      "name": "Shard Earrings",
+      "slot": "Earring",
+      "tier": "Uncommon",
+      "bonusType": "CritDMG",
+      "bonusValue": 5,
+      "isPercent": true,
+      "craftCost": 2200
+    },
+    {
+      "id": "ear_critdmg_rare",
+      "name": "Gemstone Earrings",
+      "slot": "Earring",
+      "tier": "Rare",
+      "bonusType": "CritDMG",
+      "bonusValue": 10,
+      "isPercent": true,
+      "craftCost": 11000
+    },
+    {
+      "id": "ear_critdmg_epic",
+      "name": "Crystal Earrings",
+      "slot": "Earring",
+      "tier": "Epic",
+      "bonusType": "CritDMG",
+      "bonusValue": 18,
+      "isPercent": true,
+      "craftCost": 58000
+    },
+    {
+      "id": "ear_critdmg_legendary",
+      "name": "Chaos Earrings",
+      "slot": "Earring",
+      "tier": "Legendary",
+      "bonusType": "CritDMG",
+      "bonusValue": 30,
+      "isPercent": true,
+      "craftCost": 300000
+    },
+    {
+      "id": "ear_dodge_rare",
+      "name": "Phantom Earrings",
+      "slot": "Earring",
+      "tier": "Rare",
+      "bonusType": "Dodge",
+      "bonusValue": 3,
+      "isPercent": true,
+      "craftCost": 12000
+    },
+    {
+      "id": "ear_dodge_epic",
+      "name": "Shade Earrings",
+      "slot": "Earring",
+      "tier": "Epic",
+      "bonusType": "Dodge",
+      "bonusValue": 6,
+      "isPercent": true,
+      "craftCost": 62000
+    },
+    {
+      "id": "brace_acc_uncommon",
+      "name": "Copper Bracelet",
+      "slot": "Bracelet",
+      "tier": "Uncommon",
+      "bonusType": "Accuracy",
+      "bonusValue": 50,
+      "isPercent": false,
+      "craftCost": 1700
+    },
+    {
+      "id": "brace_acc_rare",
+      "name": "Runed Bracelet",
+      "slot": "Bracelet",
+      "tier": "Rare",
+      "bonusType": "Accuracy",
+      "bonusValue": 150,
+      "isPercent": false,
+      "craftCost": 8500
+    },
+    {
+      "id": "brace_acc_epic",
+      "name": "Arcane Bracelet",
+      "slot": "Bracelet",
+      "tier": "Epic",
+      "bonusType": "Accuracy",
+      "bonusValue": 400,
+      "isPercent": false,
+      "craftCost": 45000
+    },
+    {
+      "id": "brace_atk_epic",
+      "name": "War Bracelet",
+      "slot": "Bracelet",
+      "tier": "Epic",
+      "bonusType": "ATK",
+      "bonusValue": 900,
+      "isPercent": false,
+      "craftCost": 47000
+    },
+    {
+      "id": "brace_atk_legendary",
+      "name": "Warlord Bracelet",
+      "slot": "Bracelet",
+      "tier": "Legendary",
+      "bonusType": "ATK",
+      "bonusValue": 4,
+      "isPercent": true,
+      "craftCost": 230000
+    },
+    {
+      "id": "brace_hp_legendary",
+      "name": "Vitality Bracelet",
+      "slot": "Bracelet",
+      "tier": "Legendary",
+      "bonusType": "HP",
+      "bonusValue": 7,
+      "isPercent": true,
+      "craftCost": 235000
+    }
+  ],
+  "levelMultipliers": [
+    {
+      "level": 1,
+      "atkMultiplier": 1.01,
+      "hpMultiplier": 1.008,
+      "defMultiplier": 1.006,
+      "goldCost": 1000,
+      "crystalCost": 10
+    },
+    {
+      "level": 2,
+      "atkMultiplier": 1.0201,
+      "hpMultiplier": 1.0161,
+      "defMultiplier": 1.012,
+      "goldCost": 2000,
+      "crystalCost": 11
+    },
+    {
+      "level": 3,
+      "atkMultiplier": 1.0302,
+      "hpMultiplier": 1.0241,
+      "defMultiplier": 1.0181,
+      "goldCost": 3000,
+      "crystalCost": 12
+    },
+    {
+      "level": 4,
+      "atkMultiplier": 1.0403,
+      "hpMultiplier": 1.0322,
+      "defMultiplier": 1.0241,
+      "goldCost": 4000,
+      "crystalCost": 13
+    },
+    {
+      "level": 5,
+      "atkMultiplier": 1.0505,
+      "hpMultiplier": 1.0403,
+      "defMultiplier": 1.0302,
+      "goldCost": 5000,
+      "crystalCost": 14
+    },
+    {
+      "level": 6,
+      "atkMultiplier": 1.0607,
+      "hpMultiplier": 1.0485,
+      "defMultiplier": 1.0363,
+      "goldCost": 6000,
+      "crystalCost": 15
+    },
+    {
+      "level": 7,
+      "atkMultiplier": 1.071,
+      "hpMultiplier": 1.0567,
+      "defMultiplier": 1.0424,
+      "goldCost": 7000,
+      "crystalCost": 16
+    },
+    {
+      "level": 8,
+      "atkMultiplier": 1.0813,
+      "hpMultiplier": 1.0649,
+      "defMultiplier": 1.0485,
+      "goldCost": 8000,
+      "crystalCost": 17
+    },
+    {
+      "level": 9,
+      "atkMultiplier": 1.0916,
+      "hpMultiplier": 1.0731,
+      "defMultiplier": 1.0547,
+      "goldCost": 9000,
+      "crystalCost": 18
+    },
+    {
+      "level": 10,
+      "atkMultiplier": 1.102,
+      "hpMultiplier": 1.0813,
+      "defMultiplier": 1.0609,
+      "goldCost": 10000,
+      "crystalCost": 19
+    },
+    {
+      "level": 11,
+      "atkMultiplier": 1.1124,
+      "hpMultiplier": 1.0896,
+      "defMultiplier": 1.067,
+      "goldCost": 11000,
+      "crystalCost": 20
+    },
+    {
+      "level": 12,
+      "atkMultiplier": 1.1229,
+      "hpMultiplier": 1.0979,
+      "defMultiplier": 1.0732,
+      "goldCost": 12000,
+      "crystalCost": 21
+    },
+    {
+      "level": 13,
+      "atkMultiplier": 1.1334,
+      "hpMultiplier": 1.1063,
+      "defMultiplier": 1.0794,
+      "goldCost": 13000,
+      "crystalCost": 22
+    },
+    {
+      "level": 14,
+      "atkMultiplier": 1.1439,
+      "hpMultiplier": 1.1146,
+      "defMultiplier": 1.0857,
+      "goldCost": 14000,
+      "crystalCost": 23
+    },
+    {
+      "level": 15,
+      "atkMultiplier": 1.1545,
+      "hpMultiplier": 1.123,
+      "defMultiplier": 1.0919,
+      "goldCost": 15000,
+      "crystalCost": 24
+    },
+    {
+      "level": 16,
+      "atkMultiplier": 1.1651,
+      "hpMultiplier": 1.1314,
+      "defMultiplier": 1.0982,
+      "goldCost": 16000,
+      "crystalCost": 25
+    },
+    {
+      "level": 17,
+      "atkMultiplier": 1.1758,
+      "hpMultiplier": 1.1399,
+      "defMultiplier": 1.1045,
+      "goldCost": 17000,
+      "crystalCost": 26
+    },
+    {
+      "level": 18,
+      "atkMultiplier": 1.1865,
+      "hpMultiplier": 1.1483,
+      "defMultiplier": 1.1108,
+      "goldCost": 18000,
+      "crystalCost": 27
+    },
+    {
+      "level": 19,
+      "atkMultiplier": 1.1972,
+      "hpMultiplier": 1.1568,
+      "defMultiplier": 1.1171,
+      "goldCost": 19000,
+      "crystalCost": 28
+    },
+    {
+      "level": 20,
+      "atkMultiplier": 1.208,
+      "hpMultiplier": 1.1653,
+      "defMultiplier": 1.1234,
+      "goldCost": 20000,
+      "crystalCost": 29
+    },
+    {
+      "level": 21,
+      "atkMultiplier": 1.2188,
+      "hpMultiplier": 1.1739,
+      "defMultiplier": 1.1298,
+      "goldCost": 21000,
+      "crystalCost": 30
+    },
+    {
+      "level": 22,
+      "atkMultiplier": 1.2297,
+      "hpMultiplier": 1.1825,
+      "defMultiplier": 1.1361,
+      "goldCost": 22000,
+      "crystalCost": 31
+    },
+    {
+      "level": 23,
+      "atkMultiplier": 1.2406,
+      "hpMultiplier": 1.1911,
+      "defMultiplier": 1.1425,
+      "goldCost": 23000,
+      "crystalCost": 32
+    },
+    {
+      "level": 24,
+      "atkMultiplier": 1.2515,
+      "hpMultiplier": 1.1997,
+      "defMultiplier": 1.1489,
+      "goldCost": 24000,
+      "crystalCost": 33
+    },
+    {
+      "level": 25,
+      "atkMultiplier": 1.2625,
+      "hpMultiplier": 1.2083,
+      "defMultiplier": 1.1554,
+      "goldCost": 25000,
+      "crystalCost": 34
+    },
+    {
+      "level": 26,
+      "atkMultiplier": 1.2735,
+      "hpMultiplier": 1.217,
+      "defMultiplier": 1.1618,
+      "goldCost": 26000,
+      "crystalCost": 35
+    },
+    {
+      "level": 27,
+      "atkMultiplier": 1.2846,
+      "hpMultiplier": 1.2257,
+      "defMultiplier": 1.1682,
+      "goldCost": 27000,
+      "crystalCost": 36
+    },
+    {
+      "level": 28,
+      "atkMultiplier": 1.2957,
+      "hpMultiplier": 1.2345,
+      "defMultiplier": 1.1747,
+      "goldCost": 28000,
+      "crystalCost": 37
+    },
+    {
+      "level": 29,
+      "atkMultiplier": 1.3068,
+      "hpMultiplier": 1.2432,
+      "defMultiplier": 1.1812,
+      "goldCost": 29000,
+      "crystalCost": 38
+    },
+    {
+      "level": 30,
+      "atkMultiplier": 1.318,
+      "hpMultiplier": 1.252,
+      "defMultiplier": 1.1877,
+      "goldCost": 30000,
+      "crystalCost": 39
+    },
+    {
+      "level": 31,
+      "atkMultiplier": 1.3292,
+      "hpMultiplier": 1.2608,
+      "defMultiplier": 1.1942,
+      "goldCost": 31000,
+      "crystalCost": 40
+    },
+    {
+      "level": 32,
+      "atkMultiplier": 1.3405,
+      "hpMultiplier": 1.2697,
+      "defMultiplier": 1.2008,
+      "goldCost": 32000,
+      "crystalCost": 41
+    },
+    {
+      "level": 33,
+      "atkMultiplier": 1.3518,
+      "hpMultiplier": 1.2785,
+      "defMultiplier": 1.2073,
+      "goldCost": 33000,
+      "crystalCost": 42
+    },
+    {
+      "level": 34,
+      "atkMultiplier": 1.3631,
+      "hpMultiplier": 1.2874,
+      "defMultiplier": 1.2139,
+      "goldCost": 34000,
+      "crystalCost": 43
+    },
+    {
+      "level": 35,
+      "atkMultiplier": 1.3745,
+      "hpMultiplier": 1.2963,
+      "defMultiplier": 1.2205,
+      "goldCost": 35000,
+      "crystalCost": 44
+    },
+    {
+      "level": 36,
+      "atkMultiplier": 1.3859,
+      "hpMultiplier": 1.3053,
+      "defMultiplier": 1.2271,
+      "goldCost": 36000,
+      "crystalCost": 45
+    },
+    {
+      "level": 37,
+      "atkMultiplier": 1.3974,
+      "hpMultiplier": 1.3143,
+      "defMultiplier": 1.2337,
+      "goldCost": 37000,
+      "crystalCost": 46
+    },
+    {
+      "level": 38,
+      "atkMultiplier": 1.4089,
+      "hpMultiplier": 1.3233,
+      "defMultiplier": 1.2404,
+      "goldCost": 38000,
+      "crystalCost": 47
+    },
+    {
+      "level": 39,
+      "atkMultiplier": 1.4204,
+      "hpMultiplier": 1.3323,
+      "defMultiplier": 1.247,
+      "goldCost": 39000,
+      "crystalCost": 48
+    },
+    {
+      "level": 40,
+      "atkMultiplier": 1.432,
+      "hpMultiplier": 1.3413,
+      "defMultiplier": 1.2537,
+      "goldCost": 40000,
+      "crystalCost": 49
+    },
+    {
+      "level": 41,
+      "atkMultiplier": 1.4436,
+      "hpMultiplier": 1.3504,
+      "defMultiplier": 1.2604,
+      "goldCost": 41000,
+      "crystalCost": 50
+    },
+    {
+      "level": 42,
+      "atkMultiplier": 1.4553,
+      "hpMultiplier": 1.3595,
+      "defMultiplier": 1.2671,
+      "goldCost": 42000,
+      "crystalCost": 51
+    },
+    {
+      "level": 43,
+      "atkMultiplier": 1.467,
+      "hpMultiplier": 1.3687,
+      "defMultiplier": 1.2738,
+      "goldCost": 43000,
+      "crystalCost": 52
+    },
+    {
+      "level": 44,
+      "atkMultiplier": 1.4787,
+      "hpMultiplier": 1.3778,
+      "defMultiplier": 1.2806,
+      "goldCost": 44000,
+      "crystalCost": 53
+    },
+    {
+      "level": 45,
+      "atkMultiplier": 1.4905,
+      "hpMultiplier": 1.387,
+      "defMultiplier": 1.2874,
+      "goldCost": 45000,
+      "crystalCost": 54
+    },
+    {
+      "level": 46,
+      "atkMultiplier": 1.5023,
+      "hpMultiplier": 1.3962,
+      "defMultiplier": 1.2941,
+      "goldCost": 46000,
+      "crystalCost": 55
+    },
+    {
+      "level": 47,
+      "atkMultiplier": 1.5142,
+      "hpMultiplier": 1.4055,
+      "defMultiplier": 1.3009,
+      "goldCost": 47000,
+      "crystalCost": 56
+    },
+    {
+      "level": 48,
+      "atkMultiplier": 1.5261,
+      "hpMultiplier": 1.4147,
+      "defMultiplier": 1.3077,
+      "goldCost": 48000,
+      "crystalCost": 57
+    },
+    {
+      "level": 49,
+      "atkMultiplier": 1.538,
+      "hpMultiplier": 1.424,
+      "defMultiplier": 1.3146,
+      "goldCost": 49000,
+      "crystalCost": 58
+    },
+    {
+      "level": 50,
+      "atkMultiplier": 1.55,
+      "hpMultiplier": 1.4333,
+      "defMultiplier": 1.3214,
+      "goldCost": 50000,
+      "crystalCost": 59
+    },
+    {
+      "level": 51,
+      "atkMultiplier": 1.562,
+      "hpMultiplier": 1.4427,
+      "defMultiplier": 1.3283,
+      "goldCost": 51000,
+      "crystalCost": 60
+    },
+    {
+      "level": 52,
+      "atkMultiplier": 1.5741,
+      "hpMultiplier": 1.4521,
+      "defMultiplier": 1.3352,
+      "goldCost": 52000,
+      "crystalCost": 61
+    },
+    {
+      "level": 53,
+      "atkMultiplier": 1.5862,
+      "hpMultiplier": 1.4615,
+      "defMultiplier": 1.3421,
+      "goldCost": 53000,
+      "crystalCost": 62
+    },
+    {
+      "level": 54,
+      "atkMultiplier": 1.5983,
+      "hpMultiplier": 1.4709,
+      "defMultiplier": 1.349,
+      "goldCost": 54000,
+      "crystalCost": 63
+    },
+    {
+      "level": 55,
+      "atkMultiplier": 1.6105,
+      "hpMultiplier": 1.4803,
+      "defMultiplier": 1.3559,
+      "goldCost": 55000,
+      "crystalCost": 64
+    },
+    {
+      "level": 56,
+      "atkMultiplier": 1.6227,
+      "hpMultiplier": 1.4898,
+      "defMultiplier": 1.3629,
+      "goldCost": 56000,
+      "crystalCost": 65
+    },
+    {
+      "level": 57,
+      "atkMultiplier": 1.635,
+      "hpMultiplier": 1.4993,
+      "defMultiplier": 1.3698,
+      "goldCost": 57000,
+      "crystalCost": 66
+    },
+    {
+      "level": 58,
+      "atkMultiplier": 1.6473,
+      "hpMultiplier": 1.5089,
+      "defMultiplier": 1.3768,
+      "goldCost": 58000,
+      "crystalCost": 67
+    },
+    {
+      "level": 59,
+      "atkMultiplier": 1.6596,
+      "hpMultiplier": 1.5184,
+      "defMultiplier": 1.3838,
+      "goldCost": 59000,
+      "crystalCost": 68
+    },
+    {
+      "level": 60,
+      "atkMultiplier": 1.672,
+      "hpMultiplier": 1.528,
+      "defMultiplier": 1.3909,
+      "goldCost": 60000,
+      "crystalCost": 69
+    },
+    {
+      "level": 61,
+      "atkMultiplier": 1.6844,
+      "hpMultiplier": 1.5376,
+      "defMultiplier": 1.3979,
+      "goldCost": 61000,
+      "crystalCost": 70
+    },
+    {
+      "level": 62,
+      "atkMultiplier": 1.6969,
+      "hpMultiplier": 1.5473,
+      "defMultiplier": 1.4049,
+      "goldCost": 62000,
+      "crystalCost": 71
+    },
+    {
+      "level": 63,
+      "atkMultiplier": 1.7094,
+      "hpMultiplier": 1.5569,
+      "defMultiplier": 1.412,
+      "goldCost": 63000,
+      "crystalCost": 72
+    },
+    {
+      "level": 64,
+      "atkMultiplier": 1.7219,
+      "hpMultiplier": 1.5666,
+      "defMultiplier": 1.4191,
+      "goldCost": 64000,
+      "crystalCost": 73
+    },
+    {
+      "level": 65,
+      "atkMultiplier": 1.7345,
+      "hpMultiplier": 1.5763,
+      "defMultiplier": 1.4262,
+      "goldCost": 65000,
+      "crystalCost": 74
+    },
+    {
+      "level": 66,
+      "atkMultiplier": 1.7471,
+      "hpMultiplier": 1.5861,
+      "defMultiplier": 1.4333,
+      "goldCost": 66000,
+      "crystalCost": 75
+    },
+    {
+      "level": 67,
+      "atkMultiplier": 1.7598,
+      "hpMultiplier": 1.5959,
+      "defMultiplier": 1.4405,
+      "goldCost": 67000,
+      "crystalCost": 76
+    },
+    {
+      "level": 68,
+      "atkMultiplier": 1.7725,
+      "hpMultiplier": 1.6057,
+      "defMultiplier": 1.4476,
+      "goldCost": 68000,
+      "crystalCost": 77
+    },
+    {
+      "level": 69,
+      "atkMultiplier": 1.7852,
+      "hpMultiplier": 1.6155,
+      "defMultiplier": 1.4548,
+      "goldCost": 69000,
+      "crystalCost": 78
+    },
+    {
+      "level": 70,
+      "atkMultiplier": 1.798,
+      "hpMultiplier": 1.6253,
+      "defMultiplier": 1.462,
+      "goldCost": 70000,
+      "crystalCost": 79
+    },
+    {
+      "level": 71,
+      "atkMultiplier": 1.8108,
+      "hpMultiplier": 1.6352,
+      "defMultiplier": 1.4692,
+      "goldCost": 71000,
+      "crystalCost": 80
+    },
+    {
+      "level": 72,
+      "atkMultiplier": 1.8237,
+      "hpMultiplier": 1.6451,
+      "defMultiplier": 1.4764,
+      "goldCost": 72000,
+      "crystalCost": 81
+    },
+    {
+      "level": 73,
+      "atkMultiplier": 1.8366,
+      "hpMultiplier": 1.6551,
+      "defMultiplier": 1.4837,
+      "goldCost": 73000,
+      "crystalCost": 82
+    },
+    {
+      "level": 74,
+      "atkMultiplier": 1.8495,
+      "hpMultiplier": 1.665,
+      "defMultiplier": 1.4909,
+      "goldCost": 74000,
+      "crystalCost": 83
+    },
+    {
+      "level": 75,
+      "atkMultiplier": 1.8625,
+      "hpMultiplier": 1.675,
+      "defMultiplier": 1.4982,
+      "goldCost": 75000,
+      "crystalCost": 84
+    },
+    {
+      "level": 76,
+      "atkMultiplier": 1.8755,
+      "hpMultiplier": 1.685,
+      "defMultiplier": 1.5055,
+      "goldCost": 76000,
+      "crystalCost": 85
+    },
+    {
+      "level": 77,
+      "atkMultiplier": 1.8886,
+      "hpMultiplier": 1.6951,
+      "defMultiplier": 1.5128,
+      "goldCost": 77000,
+      "crystalCost": 86
+    },
+    {
+      "level": 78,
+      "atkMultiplier": 1.9017,
+      "hpMultiplier": 1.7051,
+      "defMultiplier": 1.5201,
+      "goldCost": 78000,
+      "crystalCost": 87
+    },
+    {
+      "level": 79,
+      "atkMultiplier": 1.9148,
+      "hpMultiplier": 1.7152,
+      "defMultiplier": 1.5275,
+      "goldCost": 79000,
+      "crystalCost": 88
+    },
+    {
+      "level": 80,
+      "atkMultiplier": 1.928,
+      "hpMultiplier": 1.7253,
+      "defMultiplier": 1.5349,
+      "goldCost": 80000,
+      "crystalCost": 89
+    },
+    {
+      "level": 81,
+      "atkMultiplier": 1.9412,
+      "hpMultiplier": 1.7355,
+      "defMultiplier": 1.5422,
+      "goldCost": 81000,
+      "crystalCost": 90
+    },
+    {
+      "level": 82,
+      "atkMultiplier": 1.9545,
+      "hpMultiplier": 1.7457,
+      "defMultiplier": 1.5496,
+      "goldCost": 82000,
+      "crystalCost": 91
+    },
+    {
+      "level": 83,
+      "atkMultiplier": 1.9678,
+      "hpMultiplier": 1.7559,
+      "defMultiplier": 1.557,
+      "goldCost": 83000,
+      "crystalCost": 92
+    },
+    {
+      "level": 84,
+      "atkMultiplier": 1.9811,
+      "hpMultiplier": 1.7661,
+      "defMultiplier": 1.5645,
+      "goldCost": 84000,
+      "crystalCost": 93
+    },
+    {
+      "level": 85,
+      "atkMultiplier": 1.9945,
+      "hpMultiplier": 1.7763,
+      "defMultiplier": 1.5719,
+      "goldCost": 85000,
+      "crystalCost": 94
+    },
+    {
+      "level": 86,
+      "atkMultiplier": 2.0079,
+      "hpMultiplier": 1.7866,
+      "defMultiplier": 1.5794,
+      "goldCost": 86000,
+      "crystalCost": 95
+    },
+    {
+      "level": 87,
+      "atkMultiplier": 2.0214,
+      "hpMultiplier": 1.7969,
+      "defMultiplier": 1.5869,
+      "goldCost": 87000,
+      "crystalCost": 96
+    },
+    {
+      "level": 88,
+      "atkMultiplier": 2.0349,
+      "hpMultiplier": 1.8073,
+      "defMultiplier": 1.5944,
+      "goldCost": 88000,
+      "crystalCost": 97
+    },
+    {
+      "level": 89,
+      "atkMultiplier": 2.0484,
+      "hpMultiplier": 1.8176,
+      "defMultiplier": 1.6019,
+      "goldCost": 89000,
+      "crystalCost": 98
+    },
+    {
+      "level": 90,
+      "atkMultiplier": 2.062,
+      "hpMultiplier": 1.828,
+      "defMultiplier": 1.6094,
+      "goldCost": 90000,
+      "crystalCost": 99
+    },
+    {
+      "level": 91,
+      "atkMultiplier": 2.0756,
+      "hpMultiplier": 1.8384,
+      "defMultiplier": 1.617,
+      "goldCost": 91000,
+      "crystalCost": 100
+    },
+    {
+      "level": 92,
+      "atkMultiplier": 2.0893,
+      "hpMultiplier": 1.8489,
+      "defMultiplier": 1.6245,
+      "goldCost": 92000,
+      "crystalCost": 101
+    },
+    {
+      "level": 93,
+      "atkMultiplier": 2.103,
+      "hpMultiplier": 1.8593,
+      "defMultiplier": 1.6321,
+      "goldCost": 93000,
+      "crystalCost": 102
+    },
+    {
+      "level": 94,
+      "atkMultiplier": 2.1167,
+      "hpMultiplier": 1.8698,
+      "defMultiplier": 1.6397,
+      "goldCost": 94000,
+      "crystalCost": 103
+    },
+    {
+      "level": 95,
+      "atkMultiplier": 2.1305,
+      "hpMultiplier": 1.8803,
+      "defMultiplier": 1.6474,
+      "goldCost": 95000,
+      "crystalCost": 104
+    },
+    {
+      "level": 96,
+      "atkMultiplier": 2.1443,
+      "hpMultiplier": 1.8909,
+      "defMultiplier": 1.655,
+      "goldCost": 96000,
+      "crystalCost": 105
+    },
+    {
+      "level": 97,
+      "atkMultiplier": 2.1582,
+      "hpMultiplier": 1.9015,
+      "defMultiplier": 1.6626,
+      "goldCost": 97000,
+      "crystalCost": 106
+    },
+    {
+      "level": 98,
+      "atkMultiplier": 2.1721,
+      "hpMultiplier": 1.9121,
+      "defMultiplier": 1.6703,
+      "goldCost": 98000,
+      "crystalCost": 107
+    },
+    {
+      "level": 99,
+      "atkMultiplier": 2.186,
+      "hpMultiplier": 1.9227,
+      "defMultiplier": 1.678,
+      "goldCost": 99000,
+      "crystalCost": 108
+    },
+    {
+      "level": 100,
+      "atkMultiplier": 2.2,
+      "hpMultiplier": 1.9333,
+      "defMultiplier": 1.6857,
+      "goldCost": 100000,
+      "crystalCost": 109
+    },
+    {
+      "level": 101,
+      "atkMultiplier": 2.214,
+      "hpMultiplier": 1.944,
+      "defMultiplier": 1.6934,
+      "goldCost": 105000,
+      "crystalCost": 111
+    },
+    {
+      "level": 102,
+      "atkMultiplier": 2.2281,
+      "hpMultiplier": 1.9547,
+      "defMultiplier": 1.7012,
+      "goldCost": 110000,
+      "crystalCost": 113
+    },
+    {
+      "level": 103,
+      "atkMultiplier": 2.2422,
+      "hpMultiplier": 1.9655,
+      "defMultiplier": 1.7089,
+      "goldCost": 115000,
+      "crystalCost": 115
+    },
+    {
+      "level": 104,
+      "atkMultiplier": 2.2563,
+      "hpMultiplier": 1.9762,
+      "defMultiplier": 1.7167,
+      "goldCost": 120000,
+      "crystalCost": 117
+    },
+    {
+      "level": 105,
+      "atkMultiplier": 2.2705,
+      "hpMultiplier": 1.987,
+      "defMultiplier": 1.7245,
+      "goldCost": 125000,
+      "crystalCost": 119
+    },
+    {
+      "level": 106,
+      "atkMultiplier": 2.2847,
+      "hpMultiplier": 1.9978,
+      "defMultiplier": 1.7323,
+      "goldCost": 130000,
+      "crystalCost": 121
+    },
+    {
+      "level": 107,
+      "atkMultiplier": 2.299,
+      "hpMultiplier": 2.0087,
+      "defMultiplier": 1.7401,
+      "goldCost": 135000,
+      "crystalCost": 123
+    },
+    {
+      "level": 108,
+      "atkMultiplier": 2.3133,
+      "hpMultiplier": 2.0195,
+      "defMultiplier": 1.748,
+      "goldCost": 140000,
+      "crystalCost": 125
+    },
+    {
+      "level": 109,
+      "atkMultiplier": 2.3276,
+      "hpMultiplier": 2.0304,
+      "defMultiplier": 1.7558,
+      "goldCost": 145000,
+      "crystalCost": 127
+    },
+    {
+      "level": 110,
+      "atkMultiplier": 2.342,
+      "hpMultiplier": 2.0413,
+      "defMultiplier": 1.7637,
+      "goldCost": 150000,
+      "crystalCost": 129
+    },
+    {
+      "level": 111,
+      "atkMultiplier": 2.3564,
+      "hpMultiplier": 2.0523,
+      "defMultiplier": 1.7716,
+      "goldCost": 155000,
+      "crystalCost": 131
+    },
+    {
+      "level": 112,
+      "atkMultiplier": 2.3709,
+      "hpMultiplier": 2.0633,
+      "defMultiplier": 1.7795,
+      "goldCost": 160000,
+      "crystalCost": 133
+    },
+    {
+      "level": 113,
+      "atkMultiplier": 2.3854,
+      "hpMultiplier": 2.0743,
+      "defMultiplier": 1.7874,
+      "goldCost": 165000,
+      "crystalCost": 135
+    },
+    {
+      "level": 114,
+      "atkMultiplier": 2.3999,
+      "hpMultiplier": 2.0853,
+      "defMultiplier": 1.7954,
+      "goldCost": 170000,
+      "crystalCost": 137
+    },
+    {
+      "level": 115,
+      "atkMultiplier": 2.4145,
+      "hpMultiplier": 2.0963,
+      "defMultiplier": 1.8034,
+      "goldCost": 175000,
+      "crystalCost": 139
+    },
+    {
+      "level": 116,
+      "atkMultiplier": 2.4291,
+      "hpMultiplier": 2.1074,
+      "defMultiplier": 1.8113,
+      "goldCost": 180000,
+      "crystalCost": 141
+    },
+    {
+      "level": 117,
+      "atkMultiplier": 2.4438,
+      "hpMultiplier": 2.1185,
+      "defMultiplier": 1.8193,
+      "goldCost": 185000,
+      "crystalCost": 143
+    },
+    {
+      "level": 118,
+      "atkMultiplier": 2.4585,
+      "hpMultiplier": 2.1297,
+      "defMultiplier": 1.8273,
+      "goldCost": 190000,
+      "crystalCost": 145
+    },
+    {
+      "level": 119,
+      "atkMultiplier": 2.4732,
+      "hpMultiplier": 2.1408,
+      "defMultiplier": 1.8354,
+      "goldCost": 195000,
+      "crystalCost": 147
+    },
+    {
+      "level": 120,
+      "atkMultiplier": 2.488,
+      "hpMultiplier": 2.152,
+      "defMultiplier": 1.8434,
+      "goldCost": 200000,
+      "crystalCost": 149
+    },
+    {
+      "level": 121,
+      "atkMultiplier": 2.5028,
+      "hpMultiplier": 2.1632,
+      "defMultiplier": 1.8515,
+      "goldCost": 205000,
+      "crystalCost": 151
+    },
+    {
+      "level": 122,
+      "atkMultiplier": 2.5177,
+      "hpMultiplier": 2.1745,
+      "defMultiplier": 1.8596,
+      "goldCost": 210000,
+      "crystalCost": 153
+    },
+    {
+      "level": 123,
+      "atkMultiplier": 2.5326,
+      "hpMultiplier": 2.1857,
+      "defMultiplier": 1.8677,
+      "goldCost": 215000,
+      "crystalCost": 155
+    },
+    {
+      "level": 124,
+      "atkMultiplier": 2.5475,
+      "hpMultiplier": 2.197,
+      "defMultiplier": 1.8758,
+      "goldCost": 220000,
+      "crystalCost": 157
+    },
+    {
+      "level": 125,
+      "atkMultiplier": 2.5625,
+      "hpMultiplier": 2.2083,
+      "defMultiplier": 1.8839,
+      "goldCost": 225000,
+      "crystalCost": 159
+    },
+    {
+      "level": 126,
+      "atkMultiplier": 2.5775,
+      "hpMultiplier": 2.2197,
+      "defMultiplier": 1.8921,
+      "goldCost": 230000,
+      "crystalCost": 161
+    },
+    {
+      "level": 127,
+      "atkMultiplier": 2.5926,
+      "hpMultiplier": 2.2311,
+      "defMultiplier": 1.9002,
+      "goldCost": 235000,
+      "crystalCost": 163
+    },
+    {
+      "level": 128,
+      "atkMultiplier": 2.6077,
+      "hpMultiplier": 2.2425,
+      "defMultiplier": 1.9084,
+      "goldCost": 240000,
+      "crystalCost": 165
+    },
+    {
+      "level": 129,
+      "atkMultiplier": 2.6228,
+      "hpMultiplier": 2.2539,
+      "defMultiplier": 1.9166,
+      "goldCost": 245000,
+      "crystalCost": 167
+    },
+    {
+      "level": 130,
+      "atkMultiplier": 2.638,
+      "hpMultiplier": 2.2653,
+      "defMultiplier": 1.9249,
+      "goldCost": 250000,
+      "crystalCost": 169
+    },
+    {
+      "level": 131,
+      "atkMultiplier": 2.6532,
+      "hpMultiplier": 2.2768,
+      "defMultiplier": 1.9331,
+      "goldCost": 255000,
+      "crystalCost": 171
+    },
+    {
+      "level": 132,
+      "atkMultiplier": 2.6685,
+      "hpMultiplier": 2.2883,
+      "defMultiplier": 1.9413,
+      "goldCost": 260000,
+      "crystalCost": 173
+    },
+    {
+      "level": 133,
+      "atkMultiplier": 2.6838,
+      "hpMultiplier": 2.2999,
+      "defMultiplier": 1.9496,
+      "goldCost": 265000,
+      "crystalCost": 175
+    },
+    {
+      "level": 134,
+      "atkMultiplier": 2.6991,
+      "hpMultiplier": 2.3114,
+      "defMultiplier": 1.9579,
+      "goldCost": 270000,
+      "crystalCost": 177
+    },
+    {
+      "level": 135,
+      "atkMultiplier": 2.7145,
+      "hpMultiplier": 2.323,
+      "defMultiplier": 1.9662,
+      "goldCost": 275000,
+      "crystalCost": 179
+    },
+    {
+      "level": 136,
+      "atkMultiplier": 2.7299,
+      "hpMultiplier": 2.3346,
+      "defMultiplier": 1.9745,
+      "goldCost": 280000,
+      "crystalCost": 181
+    },
+    {
+      "level": 137,
+      "atkMultiplier": 2.7454,
+      "hpMultiplier": 2.3463,
+      "defMultiplier": 1.9829,
+      "goldCost": 285000,
+      "crystalCost": 183
+    },
+    {
+      "level": 138,
+      "atkMultiplier": 2.7609,
+      "hpMultiplier": 2.3579,
+      "defMultiplier": 1.9912,
+      "goldCost": 290000,
+      "crystalCost": 185
+    },
+    {
+      "level": 139,
+      "atkMultiplier": 2.7764,
+      "hpMultiplier": 2.3696,
+      "defMultiplier": 1.9996,
+      "goldCost": 295000,
+      "crystalCost": 187
+    },
+    {
+      "level": 140,
+      "atkMultiplier": 2.792,
+      "hpMultiplier": 2.3813,
+      "defMultiplier": 2.008,
+      "goldCost": 300000,
+      "crystalCost": 189
+    },
+    {
+      "level": 141,
+      "atkMultiplier": 2.8076,
+      "hpMultiplier": 2.3931,
+      "defMultiplier": 2.0164,
+      "goldCost": 305000,
+      "crystalCost": 191
+    },
+    {
+      "level": 142,
+      "atkMultiplier": 2.8233,
+      "hpMultiplier": 2.4049,
+      "defMultiplier": 2.0248,
+      "goldCost": 310000,
+      "crystalCost": 193
+    },
+    {
+      "level": 143,
+      "atkMultiplier": 2.839,
+      "hpMultiplier": 2.4167,
+      "defMultiplier": 2.0333,
+      "goldCost": 315000,
+      "crystalCost": 195
+    },
+    {
+      "level": 144,
+      "atkMultiplier": 2.8547,
+      "hpMultiplier": 2.4285,
+      "defMultiplier": 2.0417,
+      "goldCost": 320000,
+      "crystalCost": 197
+    },
+    {
+      "level": 145,
+      "atkMultiplier": 2.8705,
+      "hpMultiplier": 2.4403,
+      "defMultiplier": 2.0502,
+      "goldCost": 325000,
+      "crystalCost": 199
+    },
+    {
+      "level": 146,
+      "atkMultiplier": 2.8863,
+      "hpMultiplier": 2.4522,
+      "defMultiplier": 2.0587,
+      "goldCost": 330000,
+      "crystalCost": 201
+    },
+    {
+      "level": 147,
+      "atkMultiplier": 2.9022,
+      "hpMultiplier": 2.4641,
+      "defMultiplier": 2.0672,
+      "goldCost": 335000,
+      "crystalCost": 203
+    },
+    {
+      "level": 148,
+      "atkMultiplier": 2.9181,
+      "hpMultiplier": 2.4761,
+      "defMultiplier": 2.0757,
+      "goldCost": 340000,
+      "crystalCost": 205
+    },
+    {
+      "level": 149,
+      "atkMultiplier": 2.934,
+      "hpMultiplier": 2.488,
+      "defMultiplier": 2.0843,
+      "goldCost": 345000,
+      "crystalCost": 207
+    },
+    {
+      "level": 150,
+      "atkMultiplier": 2.95,
+      "hpMultiplier": 2.5,
+      "defMultiplier": 2.0929,
+      "goldCost": 350000,
+      "crystalCost": 209
+    },
+    {
+      "level": 151,
+      "atkMultiplier": 2.966,
+      "hpMultiplier": 2.512,
+      "defMultiplier": 2.1014,
+      "goldCost": 355000,
+      "crystalCost": 211
+    },
+    {
+      "level": 152,
+      "atkMultiplier": 2.9821,
+      "hpMultiplier": 2.5241,
+      "defMultiplier": 2.11,
+      "goldCost": 360000,
+      "crystalCost": 213
+    },
+    {
+      "level": 153,
+      "atkMultiplier": 2.9982,
+      "hpMultiplier": 2.5361,
+      "defMultiplier": 2.1186,
+      "goldCost": 365000,
+      "crystalCost": 215
+    },
+    {
+      "level": 154,
+      "atkMultiplier": 3.0143,
+      "hpMultiplier": 2.5482,
+      "defMultiplier": 2.1273,
+      "goldCost": 370000,
+      "crystalCost": 217
+    },
+    {
+      "level": 155,
+      "atkMultiplier": 3.0305,
+      "hpMultiplier": 2.5603,
+      "defMultiplier": 2.1359,
+      "goldCost": 375000,
+      "crystalCost": 219
+    },
+    {
+      "level": 156,
+      "atkMultiplier": 3.0467,
+      "hpMultiplier": 2.5725,
+      "defMultiplier": 2.1446,
+      "goldCost": 380000,
+      "crystalCost": 221
+    },
+    {
+      "level": 157,
+      "atkMultiplier": 3.063,
+      "hpMultiplier": 2.5847,
+      "defMultiplier": 2.1533,
+      "goldCost": 385000,
+      "crystalCost": 223
+    },
+    {
+      "level": 158,
+      "atkMultiplier": 3.0793,
+      "hpMultiplier": 2.5969,
+      "defMultiplier": 2.162,
+      "goldCost": 390000,
+      "crystalCost": 225
+    },
+    {
+      "level": 159,
+      "atkMultiplier": 3.0956,
+      "hpMultiplier": 2.6091,
+      "defMultiplier": 2.1707,
+      "goldCost": 395000,
+      "crystalCost": 227
+    },
+    {
+      "level": 160,
+      "atkMultiplier": 3.112,
+      "hpMultiplier": 2.6213,
+      "defMultiplier": 2.1794,
+      "goldCost": 400000,
+      "crystalCost": 229
+    },
+    {
+      "level": 161,
+      "atkMultiplier": 3.1284,
+      "hpMultiplier": 2.6336,
+      "defMultiplier": 2.1882,
+      "goldCost": 405000,
+      "crystalCost": 231
+    },
+    {
+      "level": 162,
+      "atkMultiplier": 3.1449,
+      "hpMultiplier": 2.6459,
+      "defMultiplier": 2.1969,
+      "goldCost": 410000,
+      "crystalCost": 233
+    },
+    {
+      "level": 163,
+      "atkMultiplier": 3.1614,
+      "hpMultiplier": 2.6583,
+      "defMultiplier": 2.2057,
+      "goldCost": 415000,
+      "crystalCost": 235
+    },
+    {
+      "level": 164,
+      "atkMultiplier": 3.1779,
+      "hpMultiplier": 2.6706,
+      "defMultiplier": 2.2145,
+      "goldCost": 420000,
+      "crystalCost": 237
+    },
+    {
+      "level": 165,
+      "atkMultiplier": 3.1945,
+      "hpMultiplier": 2.683,
+      "defMultiplier": 2.2234,
+      "goldCost": 425000,
+      "crystalCost": 239
+    },
+    {
+      "level": 166,
+      "atkMultiplier": 3.2111,
+      "hpMultiplier": 2.6954,
+      "defMultiplier": 2.2322,
+      "goldCost": 430000,
+      "crystalCost": 241
+    },
+    {
+      "level": 167,
+      "atkMultiplier": 3.2278,
+      "hpMultiplier": 2.7079,
+      "defMultiplier": 2.241,
+      "goldCost": 435000,
+      "crystalCost": 243
+    },
+    {
+      "level": 168,
+      "atkMultiplier": 3.2445,
+      "hpMultiplier": 2.7203,
+      "defMultiplier": 2.2499,
+      "goldCost": 440000,
+      "crystalCost": 245
+    },
+    {
+      "level": 169,
+      "atkMultiplier": 3.2612,
+      "hpMultiplier": 2.7328,
+      "defMultiplier": 2.2588,
+      "goldCost": 445000,
+      "crystalCost": 247
+    },
+    {
+      "level": 170,
+      "atkMultiplier": 3.278,
+      "hpMultiplier": 2.7453,
+      "defMultiplier": 2.2677,
+      "goldCost": 450000,
+      "crystalCost": 249
+    },
+    {
+      "level": 171,
+      "atkMultiplier": 3.2948,
+      "hpMultiplier": 2.7579,
+      "defMultiplier": 2.2766,
+      "goldCost": 455000,
+      "crystalCost": 251
+    },
+    {
+      "level": 172,
+      "atkMultiplier": 3.3117,
+      "hpMultiplier": 2.7705,
+      "defMultiplier": 2.2856,
+      "goldCost": 460000,
+      "crystalCost": 253
+    },
+    {
+      "level": 173,
+      "atkMultiplier": 3.3286,
+      "hpMultiplier": 2.7831,
+      "defMultiplier": 2.2945,
+      "goldCost": 465000,
+      "crystalCost": 255
+    },
+    {
+      "level": 174,
+      "atkMultiplier": 3.3455,
+      "hpMultiplier": 2.7957,
+      "defMultiplier": 2.3035,
+      "goldCost": 470000,
+      "crystalCost": 257
+    },
+    {
+      "level": 175,
+      "atkMultiplier": 3.3625,
+      "hpMultiplier": 2.8083,
+      "defMultiplier": 2.3125,
+      "goldCost": 475000,
+      "crystalCost": 259
+    },
+    {
+      "level": 176,
+      "atkMultiplier": 3.3795,
+      "hpMultiplier": 2.821,
+      "defMultiplier": 2.3215,
+      "goldCost": 480000,
+      "crystalCost": 261
+    },
+    {
+      "level": 177,
+      "atkMultiplier": 3.3966,
+      "hpMultiplier": 2.8337,
+      "defMultiplier": 2.3305,
+      "goldCost": 485000,
+      "crystalCost": 263
+    },
+    {
+      "level": 178,
+      "atkMultiplier": 3.4137,
+      "hpMultiplier": 2.8465,
+      "defMultiplier": 2.3396,
+      "goldCost": 490000,
+      "crystalCost": 265
+    },
+    {
+      "level": 179,
+      "atkMultiplier": 3.4308,
+      "hpMultiplier": 2.8592,
+      "defMultiplier": 2.3486,
+      "goldCost": 495000,
+      "crystalCost": 267
+    },
+    {
+      "level": 180,
+      "atkMultiplier": 3.448,
+      "hpMultiplier": 2.872,
+      "defMultiplier": 2.3577,
+      "goldCost": 500000,
+      "crystalCost": 269
+    },
+    {
+      "level": 181,
+      "atkMultiplier": 3.4652,
+      "hpMultiplier": 2.8848,
+      "defMultiplier": 2.3668,
+      "goldCost": 505000,
+      "crystalCost": 271
+    },
+    {
+      "level": 182,
+      "atkMultiplier": 3.4825,
+      "hpMultiplier": 2.8977,
+      "defMultiplier": 2.3759,
+      "goldCost": 510000,
+      "crystalCost": 273
+    },
+    {
+      "level": 183,
+      "atkMultiplier": 3.4998,
+      "hpMultiplier": 2.9105,
+      "defMultiplier": 2.385,
+      "goldCost": 515000,
+      "crystalCost": 275
+    },
+    {
+      "level": 184,
+      "atkMultiplier": 3.5171,
+      "hpMultiplier": 2.9234,
+      "defMultiplier": 2.3942,
+      "goldCost": 520000,
+      "crystalCost": 277
+    },
+    {
+      "level": 185,
+      "atkMultiplier": 3.5345,
+      "hpMultiplier": 2.9363,
+      "defMultiplier": 2.4034,
+      "goldCost": 525000,
+      "crystalCost": 279
+    },
+    {
+      "level": 186,
+      "atkMultiplier": 3.5519,
+      "hpMultiplier": 2.9493,
+      "defMultiplier": 2.4125,
+      "goldCost": 530000,
+      "crystalCost": 281
+    },
+    {
+      "level": 187,
+      "atkMultiplier": 3.5694,
+      "hpMultiplier": 2.9623,
+      "defMultiplier": 2.4217,
+      "goldCost": 535000,
+      "crystalCost": 283
+    },
+    {
+      "level": 188,
+      "atkMultiplier": 3.5869,
+      "hpMultiplier": 2.9753,
+      "defMultiplier": 2.4309,
+      "goldCost": 540000,
+      "crystalCost": 285
+    },
+    {
+      "level": 189,
+      "atkMultiplier": 3.6044,
+      "hpMultiplier": 2.9883,
+      "defMultiplier": 2.4402,
+      "goldCost": 545000,
+      "crystalCost": 287
+    },
+    {
+      "level": 190,
+      "atkMultiplier": 3.622,
+      "hpMultiplier": 3.0013,
+      "defMultiplier": 2.4494,
+      "goldCost": 550000,
+      "crystalCost": 289
+    },
+    {
+      "level": 191,
+      "atkMultiplier": 3.6396,
+      "hpMultiplier": 3.0144,
+      "defMultiplier": 2.4587,
+      "goldCost": 555000,
+      "crystalCost": 291
+    },
+    {
+      "level": 192,
+      "atkMultiplier": 3.6573,
+      "hpMultiplier": 3.0275,
+      "defMultiplier": 2.468,
+      "goldCost": 560000,
+      "crystalCost": 293
+    },
+    {
+      "level": 193,
+      "atkMultiplier": 3.675,
+      "hpMultiplier": 3.0407,
+      "defMultiplier": 2.4773,
+      "goldCost": 565000,
+      "crystalCost": 295
+    },
+    {
+      "level": 194,
+      "atkMultiplier": 3.6927,
+      "hpMultiplier": 3.0538,
+      "defMultiplier": 2.4866,
+      "goldCost": 570000,
+      "crystalCost": 297
+    },
+    {
+      "level": 195,
+      "atkMultiplier": 3.7105,
+      "hpMultiplier": 3.067,
+      "defMultiplier": 2.4959,
+      "goldCost": 575000,
+      "crystalCost": 299
+    },
+    {
+      "level": 196,
+      "atkMultiplier": 3.7283,
+      "hpMultiplier": 3.0802,
+      "defMultiplier": 2.5053,
+      "goldCost": 580000,
+      "crystalCost": 301
+    },
+    {
+      "level": 197,
+      "atkMultiplier": 3.7462,
+      "hpMultiplier": 3.0935,
+      "defMultiplier": 2.5146,
+      "goldCost": 585000,
+      "crystalCost": 303
+    },
+    {
+      "level": 198,
+      "atkMultiplier": 3.7641,
+      "hpMultiplier": 3.1067,
+      "defMultiplier": 2.524,
+      "goldCost": 590000,
+      "crystalCost": 305
+    },
+    {
+      "level": 199,
+      "atkMultiplier": 3.782,
+      "hpMultiplier": 3.12,
+      "defMultiplier": 2.5334,
+      "goldCost": 595000,
+      "crystalCost": 307
+    },
+    {
+      "level": 200,
+      "atkMultiplier": 3.8,
+      "hpMultiplier": 3.1333,
+      "defMultiplier": 2.5429,
+      "goldCost": 600000,
+      "crystalCost": 309
+    },
+    {
+      "level": 201,
+      "atkMultiplier": 3.818,
+      "hpMultiplier": 3.1467,
+      "defMultiplier": 2.5523,
+      "goldCost": 605000,
+      "crystalCost": 311
+    },
+    {
+      "level": 202,
+      "atkMultiplier": 3.8361,
+      "hpMultiplier": 3.1601,
+      "defMultiplier": 2.5617,
+      "goldCost": 610000,
+      "crystalCost": 313
+    },
+    {
+      "level": 203,
+      "atkMultiplier": 3.8542,
+      "hpMultiplier": 3.1735,
+      "defMultiplier": 2.5712,
+      "goldCost": 615000,
+      "crystalCost": 315
+    },
+    {
+      "level": 204,
+      "atkMultiplier": 3.8723,
+      "hpMultiplier": 3.1869,
+      "defMultiplier": 2.5807,
+      "goldCost": 620000,
+      "crystalCost": 317
+    },
+    {
+      "level": 205,
+      "atkMultiplier": 3.8905,
+      "hpMultiplier": 3.2003,
+      "defMultiplier": 2.5902,
+      "goldCost": 625000,
+      "crystalCost": 319
+    },
+    {
+      "level": 206,
+      "atkMultiplier": 3.9087,
+      "hpMultiplier": 3.2138,
+      "defMultiplier": 2.5997,
+      "goldCost": 630000,
+      "crystalCost": 321
+    },
+    {
+      "level": 207,
+      "atkMultiplier": 3.927,
+      "hpMultiplier": 3.2273,
+      "defMultiplier": 2.6093,
+      "goldCost": 635000,
+      "crystalCost": 323
+    },
+    {
+      "level": 208,
+      "atkMultiplier": 3.9453,
+      "hpMultiplier": 3.2409,
+      "defMultiplier": 2.6188,
+      "goldCost": 640000,
+      "crystalCost": 325
+    },
+    {
+      "level": 209,
+      "atkMultiplier": 3.9636,
+      "hpMultiplier": 3.2544,
+      "defMultiplier": 2.6284,
+      "goldCost": 645000,
+      "crystalCost": 327
+    },
+    {
+      "level": 210,
+      "atkMultiplier": 3.982,
+      "hpMultiplier": 3.268,
+      "defMultiplier": 2.638,
+      "goldCost": 650000,
+      "crystalCost": 329
+    },
+    {
+      "level": 211,
+      "atkMultiplier": 4.0004,
+      "hpMultiplier": 3.2816,
+      "defMultiplier": 2.6476,
+      "goldCost": 655000,
+      "crystalCost": 331
+    },
+    {
+      "level": 212,
+      "atkMultiplier": 4.0189,
+      "hpMultiplier": 3.2953,
+      "defMultiplier": 2.6572,
+      "goldCost": 660000,
+      "crystalCost": 333
+    },
+    {
+      "level": 213,
+      "atkMultiplier": 4.0374,
+      "hpMultiplier": 3.3089,
+      "defMultiplier": 2.6669,
+      "goldCost": 665000,
+      "crystalCost": 335
+    },
+    {
+      "level": 214,
+      "atkMultiplier": 4.0559,
+      "hpMultiplier": 3.3226,
+      "defMultiplier": 2.6765,
+      "goldCost": 670000,
+      "crystalCost": 337
+    },
+    {
+      "level": 215,
+      "atkMultiplier": 4.0745,
+      "hpMultiplier": 3.3363,
+      "defMultiplier": 2.6862,
+      "goldCost": 675000,
+      "crystalCost": 339
+    },
+    {
+      "level": 216,
+      "atkMultiplier": 4.0931,
+      "hpMultiplier": 3.3501,
+      "defMultiplier": 2.6959,
+      "goldCost": 680000,
+      "crystalCost": 341
+    },
+    {
+      "level": 217,
+      "atkMultiplier": 4.1118,
+      "hpMultiplier": 3.3639,
+      "defMultiplier": 2.7056,
+      "goldCost": 685000,
+      "crystalCost": 343
+    },
+    {
+      "level": 218,
+      "atkMultiplier": 4.1305,
+      "hpMultiplier": 3.3777,
+      "defMultiplier": 2.7153,
+      "goldCost": 690000,
+      "crystalCost": 345
+    },
+    {
+      "level": 219,
+      "atkMultiplier": 4.1492,
+      "hpMultiplier": 3.3915,
+      "defMultiplier": 2.7251,
+      "goldCost": 695000,
+      "crystalCost": 347
+    },
+    {
+      "level": 220,
+      "atkMultiplier": 4.168,
+      "hpMultiplier": 3.4053,
+      "defMultiplier": 2.7349,
+      "goldCost": 700000,
+      "crystalCost": 349
+    },
+    {
+      "level": 221,
+      "atkMultiplier": 4.1868,
+      "hpMultiplier": 3.4192,
+      "defMultiplier": 2.7446,
+      "goldCost": 705000,
+      "crystalCost": 351
+    },
+    {
+      "level": 222,
+      "atkMultiplier": 4.2057,
+      "hpMultiplier": 3.4331,
+      "defMultiplier": 2.7544,
+      "goldCost": 710000,
+      "crystalCost": 353
+    },
+    {
+      "level": 223,
+      "atkMultiplier": 4.2246,
+      "hpMultiplier": 3.4471,
+      "defMultiplier": 2.7642,
+      "goldCost": 715000,
+      "crystalCost": 355
+    },
+    {
+      "level": 224,
+      "atkMultiplier": 4.2435,
+      "hpMultiplier": 3.461,
+      "defMultiplier": 2.7741,
+      "goldCost": 720000,
+      "crystalCost": 357
+    },
+    {
+      "level": 225,
+      "atkMultiplier": 4.2625,
+      "hpMultiplier": 3.475,
+      "defMultiplier": 2.7839,
+      "goldCost": 725000,
+      "crystalCost": 359
+    },
+    {
+      "level": 226,
+      "atkMultiplier": 4.2815,
+      "hpMultiplier": 3.489,
+      "defMultiplier": 2.7938,
+      "goldCost": 730000,
+      "crystalCost": 361
+    },
+    {
+      "level": 227,
+      "atkMultiplier": 4.3006,
+      "hpMultiplier": 3.5031,
+      "defMultiplier": 2.8037,
+      "goldCost": 735000,
+      "crystalCost": 363
+    },
+    {
+      "level": 228,
+      "atkMultiplier": 4.3197,
+      "hpMultiplier": 3.5171,
+      "defMultiplier": 2.8136,
+      "goldCost": 740000,
+      "crystalCost": 365
+    },
+    {
+      "level": 229,
+      "atkMultiplier": 4.3388,
+      "hpMultiplier": 3.5312,
+      "defMultiplier": 2.8235,
+      "goldCost": 745000,
+      "crystalCost": 367
+    },
+    {
+      "level": 230,
+      "atkMultiplier": 4.358,
+      "hpMultiplier": 3.5453,
+      "defMultiplier": 2.8334,
+      "goldCost": 750000,
+      "crystalCost": 369
+    },
+    {
+      "level": 231,
+      "atkMultiplier": 4.3772,
+      "hpMultiplier": 3.5595,
+      "defMultiplier": 2.8434,
+      "goldCost": 755000,
+      "crystalCost": 371
+    },
+    {
+      "level": 232,
+      "atkMultiplier": 4.3965,
+      "hpMultiplier": 3.5737,
+      "defMultiplier": 2.8533,
+      "goldCost": 760000,
+      "crystalCost": 373
+    },
+    {
+      "level": 233,
+      "atkMultiplier": 4.4158,
+      "hpMultiplier": 3.5879,
+      "defMultiplier": 2.8633,
+      "goldCost": 765000,
+      "crystalCost": 375
+    },
+    {
+      "level": 234,
+      "atkMultiplier": 4.4351,
+      "hpMultiplier": 3.6021,
+      "defMultiplier": 2.8733,
+      "goldCost": 770000,
+      "crystalCost": 377
+    },
+    {
+      "level": 235,
+      "atkMultiplier": 4.4545,
+      "hpMultiplier": 3.6163,
+      "defMultiplier": 2.8834,
+      "goldCost": 775000,
+      "crystalCost": 379
+    },
+    {
+      "level": 236,
+      "atkMultiplier": 4.4739,
+      "hpMultiplier": 3.6306,
+      "defMultiplier": 2.8934,
+      "goldCost": 780000,
+      "crystalCost": 381
+    },
+    {
+      "level": 237,
+      "atkMultiplier": 4.4934,
+      "hpMultiplier": 3.6449,
+      "defMultiplier": 2.9034,
+      "goldCost": 785000,
+      "crystalCost": 383
+    },
+    {
+      "level": 238,
+      "atkMultiplier": 4.5129,
+      "hpMultiplier": 3.6593,
+      "defMultiplier": 2.9135,
+      "goldCost": 790000,
+      "crystalCost": 385
+    },
+    {
+      "level": 239,
+      "atkMultiplier": 4.5324,
+      "hpMultiplier": 3.6736,
+      "defMultiplier": 2.9236,
+      "goldCost": 795000,
+      "crystalCost": 387
+    },
+    {
+      "level": 240,
+      "atkMultiplier": 4.552,
+      "hpMultiplier": 3.688,
+      "defMultiplier": 2.9337,
+      "goldCost": 800000,
+      "crystalCost": 389
+    },
+    {
+      "level": 241,
+      "atkMultiplier": 4.5716,
+      "hpMultiplier": 3.7024,
+      "defMultiplier": 2.9438,
+      "goldCost": 805000,
+      "crystalCost": 391
+    },
+    {
+      "level": 242,
+      "atkMultiplier": 4.5913,
+      "hpMultiplier": 3.7169,
+      "defMultiplier": 2.954,
+      "goldCost": 810000,
+      "crystalCost": 393
+    },
+    {
+      "level": 243,
+      "atkMultiplier": 4.611,
+      "hpMultiplier": 3.7313,
+      "defMultiplier": 2.9641,
+      "goldCost": 815000,
+      "crystalCost": 395
+    },
+    {
+      "level": 244,
+      "atkMultiplier": 4.6307,
+      "hpMultiplier": 3.7458,
+      "defMultiplier": 2.9743,
+      "goldCost": 820000,
+      "crystalCost": 397
+    },
+    {
+      "level": 245,
+      "atkMultiplier": 4.6505,
+      "hpMultiplier": 3.7603,
+      "defMultiplier": 2.9845,
+      "goldCost": 825000,
+      "crystalCost": 399
+    },
+    {
+      "level": 246,
+      "atkMultiplier": 4.6703,
+      "hpMultiplier": 3.7749,
+      "defMultiplier": 2.9947,
+      "goldCost": 830000,
+      "crystalCost": 401
+    },
+    {
+      "level": 247,
+      "atkMultiplier": 4.6902,
+      "hpMultiplier": 3.7895,
+      "defMultiplier": 3.0049,
+      "goldCost": 835000,
+      "crystalCost": 403
+    },
+    {
+      "level": 248,
+      "atkMultiplier": 4.7101,
+      "hpMultiplier": 3.8041,
+      "defMultiplier": 3.0152,
+      "goldCost": 840000,
+      "crystalCost": 405
+    },
+    {
+      "level": 249,
+      "atkMultiplier": 4.73,
+      "hpMultiplier": 3.8187,
+      "defMultiplier": 3.0254,
+      "goldCost": 845000,
+      "crystalCost": 407
+    },
+    {
+      "level": 250,
+      "atkMultiplier": 4.75,
+      "hpMultiplier": 3.8333,
+      "defMultiplier": 3.0357,
+      "goldCost": 850000,
+      "crystalCost": 409
+    },
+    {
+      "level": 251,
+      "atkMultiplier": 4.77,
+      "hpMultiplier": 3.848,
+      "defMultiplier": 3.046,
+      "goldCost": 855000,
+      "crystalCost": 411
+    },
+    {
+      "level": 252,
+      "atkMultiplier": 4.7901,
+      "hpMultiplier": 3.8627,
+      "defMultiplier": 3.0563,
+      "goldCost": 860000,
+      "crystalCost": 413
+    },
+    {
+      "level": 253,
+      "atkMultiplier": 4.8102,
+      "hpMultiplier": 3.8775,
+      "defMultiplier": 3.0666,
+      "goldCost": 865000,
+      "crystalCost": 415
+    },
+    {
+      "level": 254,
+      "atkMultiplier": 4.8303,
+      "hpMultiplier": 3.8922,
+      "defMultiplier": 3.077,
+      "goldCost": 870000,
+      "crystalCost": 417
+    },
+    {
+      "level": 255,
+      "atkMultiplier": 4.8505,
+      "hpMultiplier": 3.907,
+      "defMultiplier": 3.0874,
+      "goldCost": 875000,
+      "crystalCost": 419
+    },
+    {
+      "level": 256,
+      "atkMultiplier": 4.8707,
+      "hpMultiplier": 3.9218,
+      "defMultiplier": 3.0977,
+      "goldCost": 880000,
+      "crystalCost": 421
+    },
+    {
+      "level": 257,
+      "atkMultiplier": 4.891,
+      "hpMultiplier": 3.9367,
+      "defMultiplier": 3.1081,
+      "goldCost": 885000,
+      "crystalCost": 423
+    },
+    {
+      "level": 258,
+      "atkMultiplier": 4.9113,
+      "hpMultiplier": 3.9515,
+      "defMultiplier": 3.1185,
+      "goldCost": 890000,
+      "crystalCost": 425
+    },
+    {
+      "level": 259,
+      "atkMultiplier": 4.9316,
+      "hpMultiplier": 3.9664,
+      "defMultiplier": 3.129,
+      "goldCost": 895000,
+      "crystalCost": 427
+    },
+    {
+      "level": 260,
+      "atkMultiplier": 4.952,
+      "hpMultiplier": 3.9813,
+      "defMultiplier": 3.1394,
+      "goldCost": 900000,
+      "crystalCost": 429
+    },
+    {
+      "level": 261,
+      "atkMultiplier": 4.9724,
+      "hpMultiplier": 3.9963,
+      "defMultiplier": 3.1499,
+      "goldCost": 905000,
+      "crystalCost": 431
+    },
+    {
+      "level": 262,
+      "atkMultiplier": 4.9929,
+      "hpMultiplier": 4.0113,
+      "defMultiplier": 3.1604,
+      "goldCost": 910000,
+      "crystalCost": 433
+    },
+    {
+      "level": 263,
+      "atkMultiplier": 5.0134,
+      "hpMultiplier": 4.0263,
+      "defMultiplier": 3.1709,
+      "goldCost": 915000,
+      "crystalCost": 435
+    },
+    {
+      "level": 264,
+      "atkMultiplier": 5.0339,
+      "hpMultiplier": 4.0413,
+      "defMultiplier": 3.1814,
+      "goldCost": 920000,
+      "crystalCost": 437
+    },
+    {
+      "level": 265,
+      "atkMultiplier": 5.0545,
+      "hpMultiplier": 4.0563,
+      "defMultiplier": 3.1919,
+      "goldCost": 925000,
+      "crystalCost": 439
+    },
+    {
+      "level": 266,
+      "atkMultiplier": 5.0751,
+      "hpMultiplier": 4.0714,
+      "defMultiplier": 3.2025,
+      "goldCost": 930000,
+      "crystalCost": 441
+    },
+    {
+      "level": 267,
+      "atkMultiplier": 5.0958,
+      "hpMultiplier": 4.0865,
+      "defMultiplier": 3.213,
+      "goldCost": 935000,
+      "crystalCost": 443
+    },
+    {
+      "level": 268,
+      "atkMultiplier": 5.1165,
+      "hpMultiplier": 4.1017,
+      "defMultiplier": 3.2236,
+      "goldCost": 940000,
+      "crystalCost": 445
+    },
+    {
+      "level": 269,
+      "atkMultiplier": 5.1372,
+      "hpMultiplier": 4.1168,
+      "defMultiplier": 3.2342,
+      "goldCost": 945000,
+      "crystalCost": 447
+    },
+    {
+      "level": 270,
+      "atkMultiplier": 5.158,
+      "hpMultiplier": 4.132,
+      "defMultiplier": 3.2449,
+      "goldCost": 950000,
+      "crystalCost": 449
+    },
+    {
+      "level": 271,
+      "atkMultiplier": 5.1788,
+      "hpMultiplier": 4.1472,
+      "defMultiplier": 3.2555,
+      "goldCost": 955000,
+      "crystalCost": 451
+    },
+    {
+      "level": 272,
+      "atkMultiplier": 5.1997,
+      "hpMultiplier": 4.1625,
+      "defMultiplier": 3.2661,
+      "goldCost": 960000,
+      "crystalCost": 453
+    },
+    {
+      "level": 273,
+      "atkMultiplier": 5.2206,
+      "hpMultiplier": 4.1777,
+      "defMultiplier": 3.2768,
+      "goldCost": 965000,
+      "crystalCost": 455
+    },
+    {
+      "level": 274,
+      "atkMultiplier": 5.2415,
+      "hpMultiplier": 4.193,
+      "defMultiplier": 3.2875,
+      "goldCost": 970000,
+      "crystalCost": 457
+    },
+    {
+      "level": 275,
+      "atkMultiplier": 5.2625,
+      "hpMultiplier": 4.2083,
+      "defMultiplier": 3.2982,
+      "goldCost": 975000,
+      "crystalCost": 459
+    },
+    {
+      "level": 276,
+      "atkMultiplier": 5.2835,
+      "hpMultiplier": 4.2237,
+      "defMultiplier": 3.3089,
+      "goldCost": 980000,
+      "crystalCost": 461
+    },
+    {
+      "level": 277,
+      "atkMultiplier": 5.3046,
+      "hpMultiplier": 4.2391,
+      "defMultiplier": 3.3197,
+      "goldCost": 985000,
+      "crystalCost": 463
+    },
+    {
+      "level": 278,
+      "atkMultiplier": 5.3257,
+      "hpMultiplier": 4.2545,
+      "defMultiplier": 3.3304,
+      "goldCost": 990000,
+      "crystalCost": 465
+    },
+    {
+      "level": 279,
+      "atkMultiplier": 5.3468,
+      "hpMultiplier": 4.2699,
+      "defMultiplier": 3.3412,
+      "goldCost": 995000,
+      "crystalCost": 467
+    },
+    {
+      "level": 280,
+      "atkMultiplier": 5.368,
+      "hpMultiplier": 4.2853,
+      "defMultiplier": 3.352,
+      "goldCost": 1000000,
+      "crystalCost": 469
+    },
+    {
+      "level": 281,
+      "atkMultiplier": 5.3892,
+      "hpMultiplier": 4.3008,
+      "defMultiplier": 3.3628,
+      "goldCost": 1005000,
+      "crystalCost": 471
+    },
+    {
+      "level": 282,
+      "atkMultiplier": 5.4105,
+      "hpMultiplier": 4.3163,
+      "defMultiplier": 3.3736,
+      "goldCost": 1010000,
+      "crystalCost": 473
+    },
+    {
+      "level": 283,
+      "atkMultiplier": 5.4318,
+      "hpMultiplier": 4.3319,
+      "defMultiplier": 3.3845,
+      "goldCost": 1015000,
+      "crystalCost": 475
+    },
+    {
+      "level": 284,
+      "atkMultiplier": 5.4531,
+      "hpMultiplier": 4.3474,
+      "defMultiplier": 3.3953,
+      "goldCost": 1020000,
+      "crystalCost": 477
+    },
+    {
+      "level": 285,
+      "atkMultiplier": 5.4745,
+      "hpMultiplier": 4.363,
+      "defMultiplier": 3.4062,
+      "goldCost": 1025000,
+      "crystalCost": 479
+    },
+    {
+      "level": 286,
+      "atkMultiplier": 5.4959,
+      "hpMultiplier": 4.3786,
+      "defMultiplier": 3.4171,
+      "goldCost": 1030000,
+      "crystalCost": 481
+    },
+    {
+      "level": 287,
+      "atkMultiplier": 5.5174,
+      "hpMultiplier": 4.3943,
+      "defMultiplier": 3.428,
+      "goldCost": 1035000,
+      "crystalCost": 483
+    },
+    {
+      "level": 288,
+      "atkMultiplier": 5.5389,
+      "hpMultiplier": 4.4099,
+      "defMultiplier": 3.4389,
+      "goldCost": 1040000,
+      "crystalCost": 485
+    },
+    {
+      "level": 289,
+      "atkMultiplier": 5.5604,
+      "hpMultiplier": 4.4256,
+      "defMultiplier": 3.4499,
+      "goldCost": 1045000,
+      "crystalCost": 487
+    },
+    {
+      "level": 290,
+      "atkMultiplier": 5.582,
+      "hpMultiplier": 4.4413,
+      "defMultiplier": 3.4609,
+      "goldCost": 1050000,
+      "crystalCost": 489
+    },
+    {
+      "level": 291,
+      "atkMultiplier": 5.6036,
+      "hpMultiplier": 4.4571,
+      "defMultiplier": 3.4718,
+      "goldCost": 1055000,
+      "crystalCost": 491
+    },
+    {
+      "level": 292,
+      "atkMultiplier": 5.6253,
+      "hpMultiplier": 4.4729,
+      "defMultiplier": 3.4828,
+      "goldCost": 1060000,
+      "crystalCost": 493
+    },
+    {
+      "level": 293,
+      "atkMultiplier": 5.647,
+      "hpMultiplier": 4.4887,
+      "defMultiplier": 3.4938,
+      "goldCost": 1065000,
+      "crystalCost": 495
+    },
+    {
+      "level": 294,
+      "atkMultiplier": 5.6687,
+      "hpMultiplier": 4.5045,
+      "defMultiplier": 3.5049,
+      "goldCost": 1070000,
+      "crystalCost": 497
+    },
+    {
+      "level": 295,
+      "atkMultiplier": 5.6905,
+      "hpMultiplier": 4.5203,
+      "defMultiplier": 3.5159,
+      "goldCost": 1075000,
+      "crystalCost": 499
+    },
+    {
+      "level": 296,
+      "atkMultiplier": 5.7123,
+      "hpMultiplier": 4.5362,
+      "defMultiplier": 3.527,
+      "goldCost": 1080000,
+      "crystalCost": 501
+    },
+    {
+      "level": 297,
+      "atkMultiplier": 5.7342,
+      "hpMultiplier": 4.5521,
+      "defMultiplier": 3.5381,
+      "goldCost": 1085000,
+      "crystalCost": 503
+    },
+    {
+      "level": 298,
+      "atkMultiplier": 5.7561,
+      "hpMultiplier": 4.5681,
+      "defMultiplier": 3.5492,
+      "goldCost": 1090000,
+      "crystalCost": 505
+    },
+    {
+      "level": 299,
+      "atkMultiplier": 5.778,
+      "hpMultiplier": 4.584,
+      "defMultiplier": 3.5603,
+      "goldCost": 1095000,
+      "crystalCost": 507
+    },
+    {
+      "level": 300,
+      "atkMultiplier": 5.8,
+      "hpMultiplier": 4.6,
+      "defMultiplier": 3.5714,
+      "goldCost": 1100000,
+      "crystalCost": 509
+    },
+    {
+      "level": 301,
+      "atkMultiplier": 5.822,
+      "hpMultiplier": 4.616,
+      "defMultiplier": 3.5826,
+      "goldCost": 1130000,
+      "crystalCost": 519
+    },
+    {
+      "level": 302,
+      "atkMultiplier": 5.8441,
+      "hpMultiplier": 4.6321,
+      "defMultiplier": 3.5937,
+      "goldCost": 1160000,
+      "crystalCost": 529
+    },
+    {
+      "level": 303,
+      "atkMultiplier": 5.8662,
+      "hpMultiplier": 4.6481,
+      "defMultiplier": 3.6049,
+      "goldCost": 1190000,
+      "crystalCost": 539
+    },
+    {
+      "level": 304,
+      "atkMultiplier": 5.8883,
+      "hpMultiplier": 4.6642,
+      "defMultiplier": 3.6161,
+      "goldCost": 1220000,
+      "crystalCost": 549
+    },
+    {
+      "level": 305,
+      "atkMultiplier": 5.9105,
+      "hpMultiplier": 4.6803,
+      "defMultiplier": 3.6274,
+      "goldCost": 1250000,
+      "crystalCost": 559
+    },
+    {
+      "level": 306,
+      "atkMultiplier": 5.9327,
+      "hpMultiplier": 4.6965,
+      "defMultiplier": 3.6386,
+      "goldCost": 1280000,
+      "crystalCost": 569
+    },
+    {
+      "level": 307,
+      "atkMultiplier": 5.955,
+      "hpMultiplier": 4.7127,
+      "defMultiplier": 3.6498,
+      "goldCost": 1310000,
+      "crystalCost": 579
+    },
+    {
+      "level": 308,
+      "atkMultiplier": 5.9773,
+      "hpMultiplier": 4.7289,
+      "defMultiplier": 3.6611,
+      "goldCost": 1340000,
+      "crystalCost": 589
+    },
+    {
+      "level": 309,
+      "atkMultiplier": 5.9996,
+      "hpMultiplier": 4.7451,
+      "defMultiplier": 3.6724,
+      "goldCost": 1370000,
+      "crystalCost": 599
+    },
+    {
+      "level": 310,
+      "atkMultiplier": 6.022,
+      "hpMultiplier": 4.7613,
+      "defMultiplier": 3.6837,
+      "goldCost": 1400000,
+      "crystalCost": 609
+    },
+    {
+      "level": 311,
+      "atkMultiplier": 6.0444,
+      "hpMultiplier": 4.7776,
+      "defMultiplier": 3.695,
+      "goldCost": 1430000,
+      "crystalCost": 619
+    },
+    {
+      "level": 312,
+      "atkMultiplier": 6.0669,
+      "hpMultiplier": 4.7939,
+      "defMultiplier": 3.7064,
+      "goldCost": 1460000,
+      "crystalCost": 629
+    },
+    {
+      "level": 313,
+      "atkMultiplier": 6.0894,
+      "hpMultiplier": 4.8103,
+      "defMultiplier": 3.7177,
+      "goldCost": 1490000,
+      "crystalCost": 639
+    },
+    {
+      "level": 314,
+      "atkMultiplier": 6.1119,
+      "hpMultiplier": 4.8266,
+      "defMultiplier": 3.7291,
+      "goldCost": 1520000,
+      "crystalCost": 649
+    },
+    {
+      "level": 315,
+      "atkMultiplier": 6.1345,
+      "hpMultiplier": 4.843,
+      "defMultiplier": 3.7405,
+      "goldCost": 1550000,
+      "crystalCost": 659
+    },
+    {
+      "level": 316,
+      "atkMultiplier": 6.1571,
+      "hpMultiplier": 4.8594,
+      "defMultiplier": 3.7519,
+      "goldCost": 1580000,
+      "crystalCost": 669
+    },
+    {
+      "level": 317,
+      "atkMultiplier": 6.1798,
+      "hpMultiplier": 4.8759,
+      "defMultiplier": 3.7633,
+      "goldCost": 1610000,
+      "crystalCost": 679
+    },
+    {
+      "level": 318,
+      "atkMultiplier": 6.2025,
+      "hpMultiplier": 4.8923,
+      "defMultiplier": 3.7748,
+      "goldCost": 1640000,
+      "crystalCost": 689
+    },
+    {
+      "level": 319,
+      "atkMultiplier": 6.2252,
+      "hpMultiplier": 4.9088,
+      "defMultiplier": 3.7862,
+      "goldCost": 1670000,
+      "crystalCost": 699
+    },
+    {
+      "level": 320,
+      "atkMultiplier": 6.248,
+      "hpMultiplier": 4.9253,
+      "defMultiplier": 3.7977,
+      "goldCost": 1700000,
+      "crystalCost": 709
+    },
+    {
+      "level": 321,
+      "atkMultiplier": 6.2708,
+      "hpMultiplier": 4.9419,
+      "defMultiplier": 3.8092,
+      "goldCost": 1730000,
+      "crystalCost": 719
+    },
+    {
+      "level": 322,
+      "atkMultiplier": 6.2937,
+      "hpMultiplier": 4.9585,
+      "defMultiplier": 3.8207,
+      "goldCost": 1760000,
+      "crystalCost": 729
+    },
+    {
+      "level": 323,
+      "atkMultiplier": 6.3166,
+      "hpMultiplier": 4.9751,
+      "defMultiplier": 3.8322,
+      "goldCost": 1790000,
+      "crystalCost": 739
+    },
+    {
+      "level": 324,
+      "atkMultiplier": 6.3395,
+      "hpMultiplier": 4.9917,
+      "defMultiplier": 3.8438,
+      "goldCost": 1820000,
+      "crystalCost": 749
+    },
+    {
+      "level": 325,
+      "atkMultiplier": 6.3625,
+      "hpMultiplier": 5.0083,
+      "defMultiplier": 3.8554,
+      "goldCost": 1850000,
+      "crystalCost": 759
+    },
+    {
+      "level": 326,
+      "atkMultiplier": 6.3855,
+      "hpMultiplier": 5.025,
+      "defMultiplier": 3.8669,
+      "goldCost": 1880000,
+      "crystalCost": 769
+    },
+    {
+      "level": 327,
+      "atkMultiplier": 6.4086,
+      "hpMultiplier": 5.0417,
+      "defMultiplier": 3.8785,
+      "goldCost": 1910000,
+      "crystalCost": 779
+    },
+    {
+      "level": 328,
+      "atkMultiplier": 6.4317,
+      "hpMultiplier": 5.0585,
+      "defMultiplier": 3.8901,
+      "goldCost": 1940000,
+      "crystalCost": 789
+    },
+    {
+      "level": 329,
+      "atkMultiplier": 6.4548,
+      "hpMultiplier": 5.0752,
+      "defMultiplier": 3.9018,
+      "goldCost": 1970000,
+      "crystalCost": 799
+    },
+    {
+      "level": 330,
+      "atkMultiplier": 6.478,
+      "hpMultiplier": 5.092,
+      "defMultiplier": 3.9134,
+      "goldCost": 2000000,
+      "crystalCost": 809
+    },
+    {
+      "level": 331,
+      "atkMultiplier": 6.5012,
+      "hpMultiplier": 5.1088,
+      "defMultiplier": 3.9251,
+      "goldCost": 2030000,
+      "crystalCost": 819
+    },
+    {
+      "level": 332,
+      "atkMultiplier": 6.5245,
+      "hpMultiplier": 5.1257,
+      "defMultiplier": 3.9368,
+      "goldCost": 2060000,
+      "crystalCost": 829
+    },
+    {
+      "level": 333,
+      "atkMultiplier": 6.5478,
+      "hpMultiplier": 5.1425,
+      "defMultiplier": 3.9485,
+      "goldCost": 2090000,
+      "crystalCost": 839
+    },
+    {
+      "level": 334,
+      "atkMultiplier": 6.5711,
+      "hpMultiplier": 5.1594,
+      "defMultiplier": 3.9602,
+      "goldCost": 2120000,
+      "crystalCost": 849
+    },
+    {
+      "level": 335,
+      "atkMultiplier": 6.5945,
+      "hpMultiplier": 5.1763,
+      "defMultiplier": 3.9719,
+      "goldCost": 2150000,
+      "crystalCost": 859
+    },
+    {
+      "level": 336,
+      "atkMultiplier": 6.6179,
+      "hpMultiplier": 5.1933,
+      "defMultiplier": 3.9837,
+      "goldCost": 2180000,
+      "crystalCost": 869
+    },
+    {
+      "level": 337,
+      "atkMultiplier": 6.6414,
+      "hpMultiplier": 5.2103,
+      "defMultiplier": 3.9954,
+      "goldCost": 2210000,
+      "crystalCost": 879
+    },
+    {
+      "level": 338,
+      "atkMultiplier": 6.6649,
+      "hpMultiplier": 5.2273,
+      "defMultiplier": 4.0072,
+      "goldCost": 2240000,
+      "crystalCost": 889
+    },
+    {
+      "level": 339,
+      "atkMultiplier": 6.6884,
+      "hpMultiplier": 5.2443,
+      "defMultiplier": 4.019,
+      "goldCost": 2270000,
+      "crystalCost": 899
+    },
+    {
+      "level": 340,
+      "atkMultiplier": 6.712,
+      "hpMultiplier": 5.2613,
+      "defMultiplier": 4.0309,
+      "goldCost": 2300000,
+      "crystalCost": 909
+    },
+    {
+      "level": 341,
+      "atkMultiplier": 6.7356,
+      "hpMultiplier": 5.2784,
+      "defMultiplier": 4.0427,
+      "goldCost": 2330000,
+      "crystalCost": 919
+    },
+    {
+      "level": 342,
+      "atkMultiplier": 6.7593,
+      "hpMultiplier": 5.2955,
+      "defMultiplier": 4.0545,
+      "goldCost": 2360000,
+      "crystalCost": 929
+    },
+    {
+      "level": 343,
+      "atkMultiplier": 6.783,
+      "hpMultiplier": 5.3127,
+      "defMultiplier": 4.0664,
+      "goldCost": 2390000,
+      "crystalCost": 939
+    },
+    {
+      "level": 344,
+      "atkMultiplier": 6.8067,
+      "hpMultiplier": 5.3298,
+      "defMultiplier": 4.0783,
+      "goldCost": 2420000,
+      "crystalCost": 949
+    },
+    {
+      "level": 345,
+      "atkMultiplier": 6.8305,
+      "hpMultiplier": 5.347,
+      "defMultiplier": 4.0902,
+      "goldCost": 2450000,
+      "crystalCost": 959
+    },
+    {
+      "level": 346,
+      "atkMultiplier": 6.8543,
+      "hpMultiplier": 5.3642,
+      "defMultiplier": 4.1021,
+      "goldCost": 2480000,
+      "crystalCost": 969
+    },
+    {
+      "level": 347,
+      "atkMultiplier": 6.8782,
+      "hpMultiplier": 5.3815,
+      "defMultiplier": 4.1141,
+      "goldCost": 2510000,
+      "crystalCost": 979
+    },
+    {
+      "level": 348,
+      "atkMultiplier": 6.9021,
+      "hpMultiplier": 5.3987,
+      "defMultiplier": 4.126,
+      "goldCost": 2540000,
+      "crystalCost": 989
+    },
+    {
+      "level": 349,
+      "atkMultiplier": 6.926,
+      "hpMultiplier": 5.416,
+      "defMultiplier": 4.138,
+      "goldCost": 2570000,
+      "crystalCost": 999
+    },
+    {
+      "level": 350,
+      "atkMultiplier": 6.95,
+      "hpMultiplier": 5.4333,
+      "defMultiplier": 4.15,
+      "goldCost": 2600000,
+      "crystalCost": 1009
+    },
+    {
+      "level": 351,
+      "atkMultiplier": 6.974,
+      "hpMultiplier": 5.4507,
+      "defMultiplier": 4.162,
+      "goldCost": 2630000,
+      "crystalCost": 1019
+    },
+    {
+      "level": 352,
+      "atkMultiplier": 6.9981,
+      "hpMultiplier": 5.4681,
+      "defMultiplier": 4.174,
+      "goldCost": 2660000,
+      "crystalCost": 1029
+    },
+    {
+      "level": 353,
+      "atkMultiplier": 7.0222,
+      "hpMultiplier": 5.4855,
+      "defMultiplier": 4.1861,
+      "goldCost": 2690000,
+      "crystalCost": 1039
+    },
+    {
+      "level": 354,
+      "atkMultiplier": 7.0463,
+      "hpMultiplier": 5.5029,
+      "defMultiplier": 4.1981,
+      "goldCost": 2720000,
+      "crystalCost": 1049
+    },
+    {
+      "level": 355,
+      "atkMultiplier": 7.0705,
+      "hpMultiplier": 5.5203,
+      "defMultiplier": 4.2102,
+      "goldCost": 2750000,
+      "crystalCost": 1059
+    },
+    {
+      "level": 356,
+      "atkMultiplier": 7.0947,
+      "hpMultiplier": 5.5378,
+      "defMultiplier": 4.2223,
+      "goldCost": 2780000,
+      "crystalCost": 1069
+    },
+    {
+      "level": 357,
+      "atkMultiplier": 7.119,
+      "hpMultiplier": 5.5553,
+      "defMultiplier": 4.2344,
+      "goldCost": 2810000,
+      "crystalCost": 1079
+    },
+    {
+      "level": 358,
+      "atkMultiplier": 7.1433,
+      "hpMultiplier": 5.5729,
+      "defMultiplier": 4.2465,
+      "goldCost": 2840000,
+      "crystalCost": 1089
+    },
+    {
+      "level": 359,
+      "atkMultiplier": 7.1676,
+      "hpMultiplier": 5.5904,
+      "defMultiplier": 4.2587,
+      "goldCost": 2870000,
+      "crystalCost": 1099
+    },
+    {
+      "level": 360,
+      "atkMultiplier": 7.192,
+      "hpMultiplier": 5.608,
+      "defMultiplier": 4.2709,
+      "goldCost": 2900000,
+      "crystalCost": 1109
+    },
+    {
+      "level": 361,
+      "atkMultiplier": 7.2164,
+      "hpMultiplier": 5.6256,
+      "defMultiplier": 4.283,
+      "goldCost": 2930000,
+      "crystalCost": 1119
+    },
+    {
+      "level": 362,
+      "atkMultiplier": 7.2409,
+      "hpMultiplier": 5.6433,
+      "defMultiplier": 4.2952,
+      "goldCost": 2960000,
+      "crystalCost": 1129
+    },
+    {
+      "level": 363,
+      "atkMultiplier": 7.2654,
+      "hpMultiplier": 5.6609,
+      "defMultiplier": 4.3074,
+      "goldCost": 2990000,
+      "crystalCost": 1139
+    },
+    {
+      "level": 364,
+      "atkMultiplier": 7.2899,
+      "hpMultiplier": 5.6786,
+      "defMultiplier": 4.3197,
+      "goldCost": 3020000,
+      "crystalCost": 1149
+    },
+    {
+      "level": 365,
+      "atkMultiplier": 7.3145,
+      "hpMultiplier": 5.6963,
+      "defMultiplier": 4.3319,
+      "goldCost": 3050000,
+      "crystalCost": 1159
+    },
+    {
+      "level": 366,
+      "atkMultiplier": 7.3391,
+      "hpMultiplier": 5.7141,
+      "defMultiplier": 4.3442,
+      "goldCost": 3080000,
+      "crystalCost": 1169
+    },
+    {
+      "level": 367,
+      "atkMultiplier": 7.3638,
+      "hpMultiplier": 5.7319,
+      "defMultiplier": 4.3565,
+      "goldCost": 3110000,
+      "crystalCost": 1179
+    },
+    {
+      "level": 368,
+      "atkMultiplier": 7.3885,
+      "hpMultiplier": 5.7497,
+      "defMultiplier": 4.3688,
+      "goldCost": 3140000,
+      "crystalCost": 1189
+    },
+    {
+      "level": 369,
+      "atkMultiplier": 7.4132,
+      "hpMultiplier": 5.7675,
+      "defMultiplier": 4.3811,
+      "goldCost": 3170000,
+      "crystalCost": 1199
+    },
+    {
+      "level": 370,
+      "atkMultiplier": 7.438,
+      "hpMultiplier": 5.7853,
+      "defMultiplier": 4.3934,
+      "goldCost": 3200000,
+      "crystalCost": 1209
+    },
+    {
+      "level": 371,
+      "atkMultiplier": 7.4628,
+      "hpMultiplier": 5.8032,
+      "defMultiplier": 4.4058,
+      "goldCost": 3230000,
+      "crystalCost": 1219
+    },
+    {
+      "level": 372,
+      "atkMultiplier": 7.4877,
+      "hpMultiplier": 5.8211,
+      "defMultiplier": 4.4181,
+      "goldCost": 3260000,
+      "crystalCost": 1229
+    },
+    {
+      "level": 373,
+      "atkMultiplier": 7.5126,
+      "hpMultiplier": 5.8391,
+      "defMultiplier": 4.4305,
+      "goldCost": 3290000,
+      "crystalCost": 1239
+    },
+    {
+      "level": 374,
+      "atkMultiplier": 7.5375,
+      "hpMultiplier": 5.857,
+      "defMultiplier": 4.4429,
+      "goldCost": 3320000,
+      "crystalCost": 1249
+    },
+    {
+      "level": 375,
+      "atkMultiplier": 7.5625,
+      "hpMultiplier": 5.875,
+      "defMultiplier": 4.4554,
+      "goldCost": 3350000,
+      "crystalCost": 1259
+    },
+    {
+      "level": 376,
+      "atkMultiplier": 7.5875,
+      "hpMultiplier": 5.893,
+      "defMultiplier": 4.4678,
+      "goldCost": 3380000,
+      "crystalCost": 1269
+    },
+    {
+      "level": 377,
+      "atkMultiplier": 7.6126,
+      "hpMultiplier": 5.9111,
+      "defMultiplier": 4.4802,
+      "goldCost": 3410000,
+      "crystalCost": 1279
+    },
+    {
+      "level": 378,
+      "atkMultiplier": 7.6377,
+      "hpMultiplier": 5.9291,
+      "defMultiplier": 4.4927,
+      "goldCost": 3440000,
+      "crystalCost": 1289
+    },
+    {
+      "level": 379,
+      "atkMultiplier": 7.6628,
+      "hpMultiplier": 5.9472,
+      "defMultiplier": 4.5052,
+      "goldCost": 3470000,
+      "crystalCost": 1299
+    },
+    {
+      "level": 380,
+      "atkMultiplier": 7.688,
+      "hpMultiplier": 5.9653,
+      "defMultiplier": 4.5177,
+      "goldCost": 3500000,
+      "crystalCost": 1309
+    },
+    {
+      "level": 381,
+      "atkMultiplier": 7.7132,
+      "hpMultiplier": 5.9835,
+      "defMultiplier": 4.5302,
+      "goldCost": 3530000,
+      "crystalCost": 1319
+    },
+    {
+      "level": 382,
+      "atkMultiplier": 7.7385,
+      "hpMultiplier": 6.0017,
+      "defMultiplier": 4.5428,
+      "goldCost": 3560000,
+      "crystalCost": 1329
+    },
+    {
+      "level": 383,
+      "atkMultiplier": 7.7638,
+      "hpMultiplier": 6.0199,
+      "defMultiplier": 4.5553,
+      "goldCost": 3590000,
+      "crystalCost": 1339
+    },
+    {
+      "level": 384,
+      "atkMultiplier": 7.7891,
+      "hpMultiplier": 6.0381,
+      "defMultiplier": 4.5679,
+      "goldCost": 3620000,
+      "crystalCost": 1349
+    },
+    {
+      "level": 385,
+      "atkMultiplier": 7.8145,
+      "hpMultiplier": 6.0563,
+      "defMultiplier": 4.5805,
+      "goldCost": 3650000,
+      "crystalCost": 1359
+    },
+    {
+      "level": 386,
+      "atkMultiplier": 7.8399,
+      "hpMultiplier": 6.0746,
+      "defMultiplier": 4.5931,
+      "goldCost": 3680000,
+      "crystalCost": 1369
+    },
+    {
+      "level": 387,
+      "atkMultiplier": 7.8654,
+      "hpMultiplier": 6.0929,
+      "defMultiplier": 4.6057,
+      "goldCost": 3710000,
+      "crystalCost": 1379
+    },
+    {
+      "level": 388,
+      "atkMultiplier": 7.8909,
+      "hpMultiplier": 6.1113,
+      "defMultiplier": 4.6184,
+      "goldCost": 3740000,
+      "crystalCost": 1389
+    },
+    {
+      "level": 389,
+      "atkMultiplier": 7.9164,
+      "hpMultiplier": 6.1296,
+      "defMultiplier": 4.631,
+      "goldCost": 3770000,
+      "crystalCost": 1399
+    },
+    {
+      "level": 390,
+      "atkMultiplier": 7.942,
+      "hpMultiplier": 6.148,
+      "defMultiplier": 4.6437,
+      "goldCost": 3800000,
+      "crystalCost": 1409
+    },
+    {
+      "level": 391,
+      "atkMultiplier": 7.9676,
+      "hpMultiplier": 6.1664,
+      "defMultiplier": 4.6564,
+      "goldCost": 3830000,
+      "crystalCost": 1419
+    },
+    {
+      "level": 392,
+      "atkMultiplier": 7.9933,
+      "hpMultiplier": 6.1849,
+      "defMultiplier": 4.6691,
+      "goldCost": 3860000,
+      "crystalCost": 1429
+    },
+    {
+      "level": 393,
+      "atkMultiplier": 8.019,
+      "hpMultiplier": 6.2033,
+      "defMultiplier": 4.6818,
+      "goldCost": 3890000,
+      "crystalCost": 1439
+    },
+    {
+      "level": 394,
+      "atkMultiplier": 8.0447,
+      "hpMultiplier": 6.2218,
+      "defMultiplier": 4.6946,
+      "goldCost": 3920000,
+      "crystalCost": 1449
+    },
+    {
+      "level": 395,
+      "atkMultiplier": 8.0705,
+      "hpMultiplier": 6.2403,
+      "defMultiplier": 4.7074,
+      "goldCost": 3950000,
+      "crystalCost": 1459
+    },
+    {
+      "level": 396,
+      "atkMultiplier": 8.0963,
+      "hpMultiplier": 6.2589,
+      "defMultiplier": 4.7201,
+      "goldCost": 3980000,
+      "crystalCost": 1469
+    },
+    {
+      "level": 397,
+      "atkMultiplier": 8.1222,
+      "hpMultiplier": 6.2775,
+      "defMultiplier": 4.7329,
+      "goldCost": 4010000,
+      "crystalCost": 1479
+    },
+    {
+      "level": 398,
+      "atkMultiplier": 8.1481,
+      "hpMultiplier": 6.2961,
+      "defMultiplier": 4.7457,
+      "goldCost": 4040000,
+      "crystalCost": 1489
+    },
+    {
+      "level": 399,
+      "atkMultiplier": 8.174,
+      "hpMultiplier": 6.3147,
+      "defMultiplier": 4.7586,
+      "goldCost": 4070000,
+      "crystalCost": 1499
+    },
+    {
+      "level": 400,
+      "atkMultiplier": 8.2,
+      "hpMultiplier": 6.3333,
+      "defMultiplier": 4.7714,
+      "goldCost": 4100000,
+      "crystalCost": 1509
+    },
+    {
+      "level": 401,
+      "atkMultiplier": 8.226,
+      "hpMultiplier": 6.352,
+      "defMultiplier": 4.7843,
+      "goldCost": 4130000,
+      "crystalCost": 1519
+    },
+    {
+      "level": 402,
+      "atkMultiplier": 8.2521,
+      "hpMultiplier": 6.3707,
+      "defMultiplier": 4.7972,
+      "goldCost": 4160000,
+      "crystalCost": 1529
+    },
+    {
+      "level": 403,
+      "atkMultiplier": 8.2782,
+      "hpMultiplier": 6.3895,
+      "defMultiplier": 4.8101,
+      "goldCost": 4190000,
+      "crystalCost": 1539
+    },
+    {
+      "level": 404,
+      "atkMultiplier": 8.3043,
+      "hpMultiplier": 6.4082,
+      "defMultiplier": 4.823,
+      "goldCost": 4220000,
+      "crystalCost": 1549
+    },
+    {
+      "level": 405,
+      "atkMultiplier": 8.3305,
+      "hpMultiplier": 6.427,
+      "defMultiplier": 4.8359,
+      "goldCost": 4250000,
+      "crystalCost": 1559
+    },
+    {
+      "level": 406,
+      "atkMultiplier": 8.3567,
+      "hpMultiplier": 6.4458,
+      "defMultiplier": 4.8489,
+      "goldCost": 4280000,
+      "crystalCost": 1569
+    },
+    {
+      "level": 407,
+      "atkMultiplier": 8.383,
+      "hpMultiplier": 6.4647,
+      "defMultiplier": 4.8618,
+      "goldCost": 4310000,
+      "crystalCost": 1579
+    },
+    {
+      "level": 408,
+      "atkMultiplier": 8.4093,
+      "hpMultiplier": 6.4835,
+      "defMultiplier": 4.8748,
+      "goldCost": 4340000,
+      "crystalCost": 1589
+    },
+    {
+      "level": 409,
+      "atkMultiplier": 8.4356,
+      "hpMultiplier": 6.5024,
+      "defMultiplier": 4.8878,
+      "goldCost": 4370000,
+      "crystalCost": 1599
+    },
+    {
+      "level": 410,
+      "atkMultiplier": 8.462,
+      "hpMultiplier": 6.5213,
+      "defMultiplier": 4.9009,
+      "goldCost": 4400000,
+      "crystalCost": 1609
+    },
+    {
+      "level": 411,
+      "atkMultiplier": 8.4884,
+      "hpMultiplier": 6.5403,
+      "defMultiplier": 4.9139,
+      "goldCost": 4430000,
+      "crystalCost": 1619
+    },
+    {
+      "level": 412,
+      "atkMultiplier": 8.5149,
+      "hpMultiplier": 6.5593,
+      "defMultiplier": 4.9269,
+      "goldCost": 4460000,
+      "crystalCost": 1629
+    },
+    {
+      "level": 413,
+      "atkMultiplier": 8.5414,
+      "hpMultiplier": 6.5783,
+      "defMultiplier": 4.94,
+      "goldCost": 4490000,
+      "crystalCost": 1639
+    },
+    {
+      "level": 414,
+      "atkMultiplier": 8.5679,
+      "hpMultiplier": 6.5973,
+      "defMultiplier": 4.9531,
+      "goldCost": 4520000,
+      "crystalCost": 1649
+    },
+    {
+      "level": 415,
+      "atkMultiplier": 8.5945,
+      "hpMultiplier": 6.6163,
+      "defMultiplier": 4.9662,
+      "goldCost": 4550000,
+      "crystalCost": 1659
+    },
+    {
+      "level": 416,
+      "atkMultiplier": 8.6211,
+      "hpMultiplier": 6.6354,
+      "defMultiplier": 4.9793,
+      "goldCost": 4580000,
+      "crystalCost": 1669
+    },
+    {
+      "level": 417,
+      "atkMultiplier": 8.6478,
+      "hpMultiplier": 6.6545,
+      "defMultiplier": 4.9925,
+      "goldCost": 4610000,
+      "crystalCost": 1679
+    },
+    {
+      "level": 418,
+      "atkMultiplier": 8.6745,
+      "hpMultiplier": 6.6737,
+      "defMultiplier": 5.0056,
+      "goldCost": 4640000,
+      "crystalCost": 1689
+    },
+    {
+      "level": 419,
+      "atkMultiplier": 8.7012,
+      "hpMultiplier": 6.6928,
+      "defMultiplier": 5.0188,
+      "goldCost": 4670000,
+      "crystalCost": 1699
+    },
+    {
+      "level": 420,
+      "atkMultiplier": 8.728,
+      "hpMultiplier": 6.712,
+      "defMultiplier": 5.032,
+      "goldCost": 4700000,
+      "crystalCost": 1709
+    },
+    {
+      "level": 421,
+      "atkMultiplier": 8.7548,
+      "hpMultiplier": 6.7312,
+      "defMultiplier": 5.0452,
+      "goldCost": 4730000,
+      "crystalCost": 1719
+    },
+    {
+      "level": 422,
+      "atkMultiplier": 8.7817,
+      "hpMultiplier": 6.7505,
+      "defMultiplier": 5.0584,
+      "goldCost": 4760000,
+      "crystalCost": 1729
+    },
+    {
+      "level": 423,
+      "atkMultiplier": 8.8086,
+      "hpMultiplier": 6.7697,
+      "defMultiplier": 5.0717,
+      "goldCost": 4790000,
+      "crystalCost": 1739
+    },
+    {
+      "level": 424,
+      "atkMultiplier": 8.8355,
+      "hpMultiplier": 6.789,
+      "defMultiplier": 5.0849,
+      "goldCost": 4820000,
+      "crystalCost": 1749
+    },
+    {
+      "level": 425,
+      "atkMultiplier": 8.8625,
+      "hpMultiplier": 6.8083,
+      "defMultiplier": 5.0982,
+      "goldCost": 4850000,
+      "crystalCost": 1759
+    },
+    {
+      "level": 426,
+      "atkMultiplier": 8.8895,
+      "hpMultiplier": 6.8277,
+      "defMultiplier": 5.1115,
+      "goldCost": 4880000,
+      "crystalCost": 1769
+    },
+    {
+      "level": 427,
+      "atkMultiplier": 8.9166,
+      "hpMultiplier": 6.8471,
+      "defMultiplier": 5.1248,
+      "goldCost": 4910000,
+      "crystalCost": 1779
+    },
+    {
+      "level": 428,
+      "atkMultiplier": 8.9437,
+      "hpMultiplier": 6.8665,
+      "defMultiplier": 5.1381,
+      "goldCost": 4940000,
+      "crystalCost": 1789
+    },
+    {
+      "level": 429,
+      "atkMultiplier": 8.9708,
+      "hpMultiplier": 6.8859,
+      "defMultiplier": 5.1515,
+      "goldCost": 4970000,
+      "crystalCost": 1799
+    },
+    {
+      "level": 430,
+      "atkMultiplier": 8.998,
+      "hpMultiplier": 6.9053,
+      "defMultiplier": 5.1649,
+      "goldCost": 5000000,
+      "crystalCost": 1809
+    },
+    {
+      "level": 431,
+      "atkMultiplier": 9.0252,
+      "hpMultiplier": 6.9248,
+      "defMultiplier": 5.1782,
+      "goldCost": 5030000,
+      "crystalCost": 1819
+    },
+    {
+      "level": 432,
+      "atkMultiplier": 9.0525,
+      "hpMultiplier": 6.9443,
+      "defMultiplier": 5.1916,
+      "goldCost": 5060000,
+      "crystalCost": 1829
+    },
+    {
+      "level": 433,
+      "atkMultiplier": 9.0798,
+      "hpMultiplier": 6.9639,
+      "defMultiplier": 5.205,
+      "goldCost": 5090000,
+      "crystalCost": 1839
+    },
+    {
+      "level": 434,
+      "atkMultiplier": 9.1071,
+      "hpMultiplier": 6.9834,
+      "defMultiplier": 5.2185,
+      "goldCost": 5120000,
+      "crystalCost": 1849
+    },
+    {
+      "level": 435,
+      "atkMultiplier": 9.1345,
+      "hpMultiplier": 7.003,
+      "defMultiplier": 5.2319,
+      "goldCost": 5150000,
+      "crystalCost": 1859
+    },
+    {
+      "level": 436,
+      "atkMultiplier": 9.1619,
+      "hpMultiplier": 7.0226,
+      "defMultiplier": 5.2454,
+      "goldCost": 5180000,
+      "crystalCost": 1869
+    },
+    {
+      "level": 437,
+      "atkMultiplier": 9.1894,
+      "hpMultiplier": 7.0423,
+      "defMultiplier": 5.2589,
+      "goldCost": 5210000,
+      "crystalCost": 1879
+    },
+    {
+      "level": 438,
+      "atkMultiplier": 9.2169,
+      "hpMultiplier": 7.0619,
+      "defMultiplier": 5.2724,
+      "goldCost": 5240000,
+      "crystalCost": 1889
+    },
+    {
+      "level": 439,
+      "atkMultiplier": 9.2444,
+      "hpMultiplier": 7.0816,
+      "defMultiplier": 5.2859,
+      "goldCost": 5270000,
+      "crystalCost": 1899
+    },
+    {
+      "level": 440,
+      "atkMultiplier": 9.272,
+      "hpMultiplier": 7.1013,
+      "defMultiplier": 5.2994,
+      "goldCost": 5300000,
+      "crystalCost": 1909
+    },
+    {
+      "level": 441,
+      "atkMultiplier": 9.2996,
+      "hpMultiplier": 7.1211,
+      "defMultiplier": 5.313,
+      "goldCost": 5330000,
+      "crystalCost": 1919
+    },
+    {
+      "level": 442,
+      "atkMultiplier": 9.3273,
+      "hpMultiplier": 7.1409,
+      "defMultiplier": 5.3265,
+      "goldCost": 5360000,
+      "crystalCost": 1929
+    },
+    {
+      "level": 443,
+      "atkMultiplier": 9.355,
+      "hpMultiplier": 7.1607,
+      "defMultiplier": 5.3401,
+      "goldCost": 5390000,
+      "crystalCost": 1939
+    },
+    {
+      "level": 444,
+      "atkMultiplier": 9.3827,
+      "hpMultiplier": 7.1805,
+      "defMultiplier": 5.3537,
+      "goldCost": 5420000,
+      "crystalCost": 1949
+    },
+    {
+      "level": 445,
+      "atkMultiplier": 9.4105,
+      "hpMultiplier": 7.2003,
+      "defMultiplier": 5.3674,
+      "goldCost": 5450000,
+      "crystalCost": 1959
+    },
+    {
+      "level": 446,
+      "atkMultiplier": 9.4383,
+      "hpMultiplier": 7.2202,
+      "defMultiplier": 5.381,
+      "goldCost": 5480000,
+      "crystalCost": 1969
+    },
+    {
+      "level": 447,
+      "atkMultiplier": 9.4662,
+      "hpMultiplier": 7.2401,
+      "defMultiplier": 5.3946,
+      "goldCost": 5510000,
+      "crystalCost": 1979
+    },
+    {
+      "level": 448,
+      "atkMultiplier": 9.4941,
+      "hpMultiplier": 7.2601,
+      "defMultiplier": 5.4083,
+      "goldCost": 5540000,
+      "crystalCost": 1989
+    },
+    {
+      "level": 449,
+      "atkMultiplier": 9.522,
+      "hpMultiplier": 7.28,
+      "defMultiplier": 5.422,
+      "goldCost": 5570000,
+      "crystalCost": 1999
+    },
+    {
+      "level": 450,
+      "atkMultiplier": 9.55,
+      "hpMultiplier": 7.3,
+      "defMultiplier": 5.4357,
+      "goldCost": 5600000,
+      "crystalCost": 2009
+    },
+    {
+      "level": 451,
+      "atkMultiplier": 9.578,
+      "hpMultiplier": 7.32,
+      "defMultiplier": 5.4494,
+      "goldCost": 5630000,
+      "crystalCost": 2019
+    },
+    {
+      "level": 452,
+      "atkMultiplier": 9.6061,
+      "hpMultiplier": 7.3401,
+      "defMultiplier": 5.4632,
+      "goldCost": 5660000,
+      "crystalCost": 2029
+    },
+    {
+      "level": 453,
+      "atkMultiplier": 9.6342,
+      "hpMultiplier": 7.3601,
+      "defMultiplier": 5.4769,
+      "goldCost": 5690000,
+      "crystalCost": 2039
+    },
+    {
+      "level": 454,
+      "atkMultiplier": 9.6623,
+      "hpMultiplier": 7.3802,
+      "defMultiplier": 5.4907,
+      "goldCost": 5720000,
+      "crystalCost": 2049
+    },
+    {
+      "level": 455,
+      "atkMultiplier": 9.6905,
+      "hpMultiplier": 7.4003,
+      "defMultiplier": 5.5045,
+      "goldCost": 5750000,
+      "crystalCost": 2059
+    },
+    {
+      "level": 456,
+      "atkMultiplier": 9.7187,
+      "hpMultiplier": 7.4205,
+      "defMultiplier": 5.5183,
+      "goldCost": 5780000,
+      "crystalCost": 2069
+    },
+    {
+      "level": 457,
+      "atkMultiplier": 9.747,
+      "hpMultiplier": 7.4407,
+      "defMultiplier": 5.5321,
+      "goldCost": 5810000,
+      "crystalCost": 2079
+    },
+    {
+      "level": 458,
+      "atkMultiplier": 9.7753,
+      "hpMultiplier": 7.4609,
+      "defMultiplier": 5.546,
+      "goldCost": 5840000,
+      "crystalCost": 2089
+    },
+    {
+      "level": 459,
+      "atkMultiplier": 9.8036,
+      "hpMultiplier": 7.4811,
+      "defMultiplier": 5.5598,
+      "goldCost": 5870000,
+      "crystalCost": 2099
+    },
+    {
+      "level": 460,
+      "atkMultiplier": 9.832,
+      "hpMultiplier": 7.5013,
+      "defMultiplier": 5.5737,
+      "goldCost": 5900000,
+      "crystalCost": 2109
+    },
+    {
+      "level": 461,
+      "atkMultiplier": 9.8604,
+      "hpMultiplier": 7.5216,
+      "defMultiplier": 5.5876,
+      "goldCost": 5930000,
+      "crystalCost": 2119
+    },
+    {
+      "level": 462,
+      "atkMultiplier": 9.8889,
+      "hpMultiplier": 7.5419,
+      "defMultiplier": 5.6015,
+      "goldCost": 5960000,
+      "crystalCost": 2129
+    },
+    {
+      "level": 463,
+      "atkMultiplier": 9.9174,
+      "hpMultiplier": 7.5623,
+      "defMultiplier": 5.6154,
+      "goldCost": 5990000,
+      "crystalCost": 2139
+    },
+    {
+      "level": 464,
+      "atkMultiplier": 9.9459,
+      "hpMultiplier": 7.5826,
+      "defMultiplier": 5.6294,
+      "goldCost": 6020000,
+      "crystalCost": 2149
+    },
+    {
+      "level": 465,
+      "atkMultiplier": 9.9745,
+      "hpMultiplier": 7.603,
+      "defMultiplier": 5.6434,
+      "goldCost": 6050000,
+      "crystalCost": 2159
+    },
+    {
+      "level": 466,
+      "atkMultiplier": 10.0031,
+      "hpMultiplier": 7.6234,
+      "defMultiplier": 5.6573,
+      "goldCost": 6080000,
+      "crystalCost": 2169
+    },
+    {
+      "level": 467,
+      "atkMultiplier": 10.0318,
+      "hpMultiplier": 7.6439,
+      "defMultiplier": 5.6713,
+      "goldCost": 6110000,
+      "crystalCost": 2179
+    },
+    {
+      "level": 468,
+      "atkMultiplier": 10.0605,
+      "hpMultiplier": 7.6643,
+      "defMultiplier": 5.6853,
+      "goldCost": 6140000,
+      "crystalCost": 2189
+    },
+    {
+      "level": 469,
+      "atkMultiplier": 10.0892,
+      "hpMultiplier": 7.6848,
+      "defMultiplier": 5.6994,
+      "goldCost": 6170000,
+      "crystalCost": 2199
+    },
+    {
+      "level": 470,
+      "atkMultiplier": 10.118,
+      "hpMultiplier": 7.7053,
+      "defMultiplier": 5.7134,
+      "goldCost": 6200000,
+      "crystalCost": 2209
+    },
+    {
+      "level": 471,
+      "atkMultiplier": 10.1468,
+      "hpMultiplier": 7.7259,
+      "defMultiplier": 5.7275,
+      "goldCost": 6230000,
+      "crystalCost": 2219
+    },
+    {
+      "level": 472,
+      "atkMultiplier": 10.1757,
+      "hpMultiplier": 7.7465,
+      "defMultiplier": 5.7416,
+      "goldCost": 6260000,
+      "crystalCost": 2229
+    },
+    {
+      "level": 473,
+      "atkMultiplier": 10.2046,
+      "hpMultiplier": 7.7671,
+      "defMultiplier": 5.7557,
+      "goldCost": 6290000,
+      "crystalCost": 2239
+    },
+    {
+      "level": 474,
+      "atkMultiplier": 10.2335,
+      "hpMultiplier": 7.7877,
+      "defMultiplier": 5.7698,
+      "goldCost": 6320000,
+      "crystalCost": 2249
+    },
+    {
+      "level": 475,
+      "atkMultiplier": 10.2625,
+      "hpMultiplier": 7.8083,
+      "defMultiplier": 5.7839,
+      "goldCost": 6350000,
+      "crystalCost": 2259
+    },
+    {
+      "level": 476,
+      "atkMultiplier": 10.2915,
+      "hpMultiplier": 7.829,
+      "defMultiplier": 5.7981,
+      "goldCost": 6380000,
+      "crystalCost": 2269
+    },
+    {
+      "level": 477,
+      "atkMultiplier": 10.3206,
+      "hpMultiplier": 7.8497,
+      "defMultiplier": 5.8122,
+      "goldCost": 6410000,
+      "crystalCost": 2279
+    },
+    {
+      "level": 478,
+      "atkMultiplier": 10.3497,
+      "hpMultiplier": 7.8705,
+      "defMultiplier": 5.8264,
+      "goldCost": 6440000,
+      "crystalCost": 2289
+    },
+    {
+      "level": 479,
+      "atkMultiplier": 10.3788,
+      "hpMultiplier": 7.8912,
+      "defMultiplier": 5.8406,
+      "goldCost": 6470000,
+      "crystalCost": 2299
+    },
+    {
+      "level": 480,
+      "atkMultiplier": 10.408,
+      "hpMultiplier": 7.912,
+      "defMultiplier": 5.8549,
+      "goldCost": 6500000,
+      "crystalCost": 2309
+    },
+    {
+      "level": 481,
+      "atkMultiplier": 10.4372,
+      "hpMultiplier": 7.9328,
+      "defMultiplier": 5.8691,
+      "goldCost": 6530000,
+      "crystalCost": 2319
+    },
+    {
+      "level": 482,
+      "atkMultiplier": 10.4665,
+      "hpMultiplier": 7.9537,
+      "defMultiplier": 5.8833,
+      "goldCost": 6560000,
+      "crystalCost": 2329
+    },
+    {
+      "level": 483,
+      "atkMultiplier": 10.4958,
+      "hpMultiplier": 7.9745,
+      "defMultiplier": 5.8976,
+      "goldCost": 6590000,
+      "crystalCost": 2339
+    },
+    {
+      "level": 484,
+      "atkMultiplier": 10.5251,
+      "hpMultiplier": 7.9954,
+      "defMultiplier": 5.9119,
+      "goldCost": 6620000,
+      "crystalCost": 2349
+    },
+    {
+      "level": 485,
+      "atkMultiplier": 10.5545,
+      "hpMultiplier": 8.0163,
+      "defMultiplier": 5.9262,
+      "goldCost": 6650000,
+      "crystalCost": 2359
+    },
+    {
+      "level": 486,
+      "atkMultiplier": 10.5839,
+      "hpMultiplier": 8.0373,
+      "defMultiplier": 5.9405,
+      "goldCost": 6680000,
+      "crystalCost": 2369
+    },
+    {
+      "level": 487,
+      "atkMultiplier": 10.6134,
+      "hpMultiplier": 8.0583,
+      "defMultiplier": 5.9549,
+      "goldCost": 6710000,
+      "crystalCost": 2379
+    },
+    {
+      "level": 488,
+      "atkMultiplier": 10.6429,
+      "hpMultiplier": 8.0793,
+      "defMultiplier": 5.9692,
+      "goldCost": 6740000,
+      "crystalCost": 2389
+    },
+    {
+      "level": 489,
+      "atkMultiplier": 10.6724,
+      "hpMultiplier": 8.1003,
+      "defMultiplier": 5.9836,
+      "goldCost": 6770000,
+      "crystalCost": 2399
+    },
+    {
+      "level": 490,
+      "atkMultiplier": 10.702,
+      "hpMultiplier": 8.1213,
+      "defMultiplier": 5.998,
+      "goldCost": 6800000,
+      "crystalCost": 2409
+    },
+    {
+      "level": 491,
+      "atkMultiplier": 10.7316,
+      "hpMultiplier": 8.1424,
+      "defMultiplier": 6.0124,
+      "goldCost": 6830000,
+      "crystalCost": 2419
+    },
+    {
+      "level": 492,
+      "atkMultiplier": 10.7613,
+      "hpMultiplier": 8.1635,
+      "defMultiplier": 6.0268,
+      "goldCost": 6860000,
+      "crystalCost": 2429
+    },
+    {
+      "level": 493,
+      "atkMultiplier": 10.791,
+      "hpMultiplier": 8.1847,
+      "defMultiplier": 6.0413,
+      "goldCost": 6890000,
+      "crystalCost": 2439
+    },
+    {
+      "level": 494,
+      "atkMultiplier": 10.8207,
+      "hpMultiplier": 8.2058,
+      "defMultiplier": 6.0557,
+      "goldCost": 6920000,
+      "crystalCost": 2449
+    },
+    {
+      "level": 495,
+      "atkMultiplier": 10.8505,
+      "hpMultiplier": 8.227,
+      "defMultiplier": 6.0702,
+      "goldCost": 6950000,
+      "crystalCost": 2459
+    },
+    {
+      "level": 496,
+      "atkMultiplier": 10.8803,
+      "hpMultiplier": 8.2482,
+      "defMultiplier": 6.0847,
+      "goldCost": 6980000,
+      "crystalCost": 2469
+    },
+    {
+      "level": 497,
+      "atkMultiplier": 10.9102,
+      "hpMultiplier": 8.2695,
+      "defMultiplier": 6.0992,
+      "goldCost": 7010000,
+      "crystalCost": 2479
+    },
+    {
+      "level": 498,
+      "atkMultiplier": 10.9401,
+      "hpMultiplier": 8.2907,
+      "defMultiplier": 6.1137,
+      "goldCost": 7040000,
+      "crystalCost": 2489
+    },
+    {
+      "level": 499,
+      "atkMultiplier": 10.97,
+      "hpMultiplier": 8.312,
+      "defMultiplier": 6.1283,
+      "goldCost": 7070000,
+      "crystalCost": 2499
+    },
+    {
+      "level": 500,
+      "atkMultiplier": 11,
+      "hpMultiplier": 8.3333,
+      "defMultiplier": 6.1429,
+      "goldCost": 7100000,
+      "crystalCost": 2509
+    },
+    {
+      "level": 501,
+      "atkMultiplier": 11.03,
+      "hpMultiplier": 8.3547,
+      "defMultiplier": 6.1574,
+      "goldCost": 7130000,
+      "crystalCost": 2519
+    },
+    {
+      "level": 502,
+      "atkMultiplier": 11.0601,
+      "hpMultiplier": 8.3761,
+      "defMultiplier": 6.172,
+      "goldCost": 7160000,
+      "crystalCost": 2529
+    },
+    {
+      "level": 503,
+      "atkMultiplier": 11.0902,
+      "hpMultiplier": 8.3975,
+      "defMultiplier": 6.1866,
+      "goldCost": 7190000,
+      "crystalCost": 2539
+    },
+    {
+      "level": 504,
+      "atkMultiplier": 11.1203,
+      "hpMultiplier": 8.4189,
+      "defMultiplier": 6.2013,
+      "goldCost": 7220000,
+      "crystalCost": 2549
+    },
+    {
+      "level": 505,
+      "atkMultiplier": 11.1505,
+      "hpMultiplier": 8.4403,
+      "defMultiplier": 6.2159,
+      "goldCost": 7250000,
+      "crystalCost": 2559
+    },
+    {
+      "level": 506,
+      "atkMultiplier": 11.1807,
+      "hpMultiplier": 8.4618,
+      "defMultiplier": 6.2306,
+      "goldCost": 7280000,
+      "crystalCost": 2569
+    },
+    {
+      "level": 507,
+      "atkMultiplier": 11.211,
+      "hpMultiplier": 8.4833,
+      "defMultiplier": 6.2453,
+      "goldCost": 7310000,
+      "crystalCost": 2579
+    },
+    {
+      "level": 508,
+      "atkMultiplier": 11.2413,
+      "hpMultiplier": 8.5049,
+      "defMultiplier": 6.26,
+      "goldCost": 7340000,
+      "crystalCost": 2589
+    },
+    {
+      "level": 509,
+      "atkMultiplier": 11.2716,
+      "hpMultiplier": 8.5264,
+      "defMultiplier": 6.2747,
+      "goldCost": 7370000,
+      "crystalCost": 2599
+    },
+    {
+      "level": 510,
+      "atkMultiplier": 11.302,
+      "hpMultiplier": 8.548,
+      "defMultiplier": 6.2894,
+      "goldCost": 7400000,
+      "crystalCost": 2609
+    },
+    {
+      "level": 511,
+      "atkMultiplier": 11.3324,
+      "hpMultiplier": 8.5696,
+      "defMultiplier": 6.3042,
+      "goldCost": 7430000,
+      "crystalCost": 2619
+    },
+    {
+      "level": 512,
+      "atkMultiplier": 11.3629,
+      "hpMultiplier": 8.5913,
+      "defMultiplier": 6.3189,
+      "goldCost": 7460000,
+      "crystalCost": 2629
+    },
+    {
+      "level": 513,
+      "atkMultiplier": 11.3934,
+      "hpMultiplier": 8.6129,
+      "defMultiplier": 6.3337,
+      "goldCost": 7490000,
+      "crystalCost": 2639
+    },
+    {
+      "level": 514,
+      "atkMultiplier": 11.4239,
+      "hpMultiplier": 8.6346,
+      "defMultiplier": 6.3485,
+      "goldCost": 7520000,
+      "crystalCost": 2649
+    },
+    {
+      "level": 515,
+      "atkMultiplier": 11.4545,
+      "hpMultiplier": 8.6563,
+      "defMultiplier": 6.3634,
+      "goldCost": 7550000,
+      "crystalCost": 2659
+    },
+    {
+      "level": 516,
+      "atkMultiplier": 11.4851,
+      "hpMultiplier": 8.6781,
+      "defMultiplier": 6.3782,
+      "goldCost": 7580000,
+      "crystalCost": 2669
+    },
+    {
+      "level": 517,
+      "atkMultiplier": 11.5158,
+      "hpMultiplier": 8.6999,
+      "defMultiplier": 6.393,
+      "goldCost": 7610000,
+      "crystalCost": 2679
+    },
+    {
+      "level": 518,
+      "atkMultiplier": 11.5465,
+      "hpMultiplier": 8.7217,
+      "defMultiplier": 6.4079,
+      "goldCost": 7640000,
+      "crystalCost": 2689
+    },
+    {
+      "level": 519,
+      "atkMultiplier": 11.5772,
+      "hpMultiplier": 8.7435,
+      "defMultiplier": 6.4228,
+      "goldCost": 7670000,
+      "crystalCost": 2699
+    },
+    {
+      "level": 520,
+      "atkMultiplier": 11.608,
+      "hpMultiplier": 8.7653,
+      "defMultiplier": 6.4377,
+      "goldCost": 7700000,
+      "crystalCost": 2709
+    },
+    {
+      "level": 521,
+      "atkMultiplier": 11.6388,
+      "hpMultiplier": 8.7872,
+      "defMultiplier": 6.4526,
+      "goldCost": 7730000,
+      "crystalCost": 2719
+    },
+    {
+      "level": 522,
+      "atkMultiplier": 11.6697,
+      "hpMultiplier": 8.8091,
+      "defMultiplier": 6.4676,
+      "goldCost": 7760000,
+      "crystalCost": 2729
+    },
+    {
+      "level": 523,
+      "atkMultiplier": 11.7006,
+      "hpMultiplier": 8.8311,
+      "defMultiplier": 6.4825,
+      "goldCost": 7790000,
+      "crystalCost": 2739
+    },
+    {
+      "level": 524,
+      "atkMultiplier": 11.7315,
+      "hpMultiplier": 8.853,
+      "defMultiplier": 6.4975,
+      "goldCost": 7820000,
+      "crystalCost": 2749
+    },
+    {
+      "level": 525,
+      "atkMultiplier": 11.7625,
+      "hpMultiplier": 8.875,
+      "defMultiplier": 6.5125,
+      "goldCost": 7850000,
+      "crystalCost": 2759
+    },
+    {
+      "level": 526,
+      "atkMultiplier": 11.7935,
+      "hpMultiplier": 8.897,
+      "defMultiplier": 6.5275,
+      "goldCost": 7880000,
+      "crystalCost": 2769
+    },
+    {
+      "level": 527,
+      "atkMultiplier": 11.8246,
+      "hpMultiplier": 8.9191,
+      "defMultiplier": 6.5425,
+      "goldCost": 7910000,
+      "crystalCost": 2779
+    },
+    {
+      "level": 528,
+      "atkMultiplier": 11.8557,
+      "hpMultiplier": 8.9411,
+      "defMultiplier": 6.5576,
+      "goldCost": 7940000,
+      "crystalCost": 2789
+    },
+    {
+      "level": 529,
+      "atkMultiplier": 11.8868,
+      "hpMultiplier": 8.9632,
+      "defMultiplier": 6.5726,
+      "goldCost": 7970000,
+      "crystalCost": 2799
+    },
+    {
+      "level": 530,
+      "atkMultiplier": 11.918,
+      "hpMultiplier": 8.9853,
+      "defMultiplier": 6.5877,
+      "goldCost": 8000000,
+      "crystalCost": 2809
+    },
+    {
+      "level": 531,
+      "atkMultiplier": 11.9492,
+      "hpMultiplier": 9.0075,
+      "defMultiplier": 6.6028,
+      "goldCost": 8030000,
+      "crystalCost": 2819
+    },
+    {
+      "level": 532,
+      "atkMultiplier": 11.9805,
+      "hpMultiplier": 9.0297,
+      "defMultiplier": 6.6179,
+      "goldCost": 8060000,
+      "crystalCost": 2829
+    },
+    {
+      "level": 533,
+      "atkMultiplier": 12.0118,
+      "hpMultiplier": 9.0519,
+      "defMultiplier": 6.633,
+      "goldCost": 8090000,
+      "crystalCost": 2839
+    },
+    {
+      "level": 534,
+      "atkMultiplier": 12.0431,
+      "hpMultiplier": 9.0741,
+      "defMultiplier": 6.6482,
+      "goldCost": 8120000,
+      "crystalCost": 2849
+    },
+    {
+      "level": 535,
+      "atkMultiplier": 12.0745,
+      "hpMultiplier": 9.0963,
+      "defMultiplier": 6.6634,
+      "goldCost": 8150000,
+      "crystalCost": 2859
+    },
+    {
+      "level": 536,
+      "atkMultiplier": 12.1059,
+      "hpMultiplier": 9.1186,
+      "defMultiplier": 6.6785,
+      "goldCost": 8180000,
+      "crystalCost": 2869
+    },
+    {
+      "level": 537,
+      "atkMultiplier": 12.1374,
+      "hpMultiplier": 9.1409,
+      "defMultiplier": 6.6937,
+      "goldCost": 8210000,
+      "crystalCost": 2879
+    },
+    {
+      "level": 538,
+      "atkMultiplier": 12.1689,
+      "hpMultiplier": 9.1633,
+      "defMultiplier": 6.7089,
+      "goldCost": 8240000,
+      "crystalCost": 2889
+    },
+    {
+      "level": 539,
+      "atkMultiplier": 12.2004,
+      "hpMultiplier": 9.1856,
+      "defMultiplier": 6.7242,
+      "goldCost": 8270000,
+      "crystalCost": 2899
+    },
+    {
+      "level": 540,
+      "atkMultiplier": 12.232,
+      "hpMultiplier": 9.208,
+      "defMultiplier": 6.7394,
+      "goldCost": 8300000,
+      "crystalCost": 2909
+    },
+    {
+      "level": 541,
+      "atkMultiplier": 12.2636,
+      "hpMultiplier": 9.2304,
+      "defMultiplier": 6.7547,
+      "goldCost": 8330000,
+      "crystalCost": 2919
+    },
+    {
+      "level": 542,
+      "atkMultiplier": 12.2953,
+      "hpMultiplier": 9.2529,
+      "defMultiplier": 6.77,
+      "goldCost": 8360000,
+      "crystalCost": 2929
+    },
+    {
+      "level": 543,
+      "atkMultiplier": 12.327,
+      "hpMultiplier": 9.2753,
+      "defMultiplier": 6.7853,
+      "goldCost": 8390000,
+      "crystalCost": 2939
+    },
+    {
+      "level": 544,
+      "atkMultiplier": 12.3587,
+      "hpMultiplier": 9.2978,
+      "defMultiplier": 6.8006,
+      "goldCost": 8420000,
+      "crystalCost": 2949
+    },
+    {
+      "level": 545,
+      "atkMultiplier": 12.3905,
+      "hpMultiplier": 9.3203,
+      "defMultiplier": 6.8159,
+      "goldCost": 8450000,
+      "crystalCost": 2959
+    },
+    {
+      "level": 546,
+      "atkMultiplier": 12.4223,
+      "hpMultiplier": 9.3429,
+      "defMultiplier": 6.8313,
+      "goldCost": 8480000,
+      "crystalCost": 2969
+    },
+    {
+      "level": 547,
+      "atkMultiplier": 12.4542,
+      "hpMultiplier": 9.3655,
+      "defMultiplier": 6.8466,
+      "goldCost": 8510000,
+      "crystalCost": 2979
+    },
+    {
+      "level": 548,
+      "atkMultiplier": 12.4861,
+      "hpMultiplier": 9.3881,
+      "defMultiplier": 6.862,
+      "goldCost": 8540000,
+      "crystalCost": 2989
+    },
+    {
+      "level": 549,
+      "atkMultiplier": 12.518,
+      "hpMultiplier": 9.4107,
+      "defMultiplier": 6.8774,
+      "goldCost": 8570000,
+      "crystalCost": 2999
+    },
+    {
+      "level": 550,
+      "atkMultiplier": 12.55,
+      "hpMultiplier": 9.4333,
+      "defMultiplier": 6.8929,
+      "goldCost": 8600000,
+      "crystalCost": 3009
+    },
+    {
+      "level": 551,
+      "atkMultiplier": 12.582,
+      "hpMultiplier": 9.456,
+      "defMultiplier": 6.9083,
+      "goldCost": 8630000,
+      "crystalCost": 3019
+    },
+    {
+      "level": 552,
+      "atkMultiplier": 12.6141,
+      "hpMultiplier": 9.4787,
+      "defMultiplier": 6.9237,
+      "goldCost": 8660000,
+      "crystalCost": 3029
+    },
+    {
+      "level": 553,
+      "atkMultiplier": 12.6462,
+      "hpMultiplier": 9.5015,
+      "defMultiplier": 6.9392,
+      "goldCost": 8690000,
+      "crystalCost": 3039
+    },
+    {
+      "level": 554,
+      "atkMultiplier": 12.6783,
+      "hpMultiplier": 9.5242,
+      "defMultiplier": 6.9547,
+      "goldCost": 8720000,
+      "crystalCost": 3049
+    },
+    {
+      "level": 555,
+      "atkMultiplier": 12.7105,
+      "hpMultiplier": 9.547,
+      "defMultiplier": 6.9702,
+      "goldCost": 8750000,
+      "crystalCost": 3059
+    },
+    {
+      "level": 556,
+      "atkMultiplier": 12.7427,
+      "hpMultiplier": 9.5698,
+      "defMultiplier": 6.9857,
+      "goldCost": 8780000,
+      "crystalCost": 3069
+    },
+    {
+      "level": 557,
+      "atkMultiplier": 12.775,
+      "hpMultiplier": 9.5927,
+      "defMultiplier": 7.0013,
+      "goldCost": 8810000,
+      "crystalCost": 3079
+    },
+    {
+      "level": 558,
+      "atkMultiplier": 12.8073,
+      "hpMultiplier": 9.6155,
+      "defMultiplier": 7.0168,
+      "goldCost": 8840000,
+      "crystalCost": 3089
+    },
+    {
+      "level": 559,
+      "atkMultiplier": 12.8396,
+      "hpMultiplier": 9.6384,
+      "defMultiplier": 7.0324,
+      "goldCost": 8870000,
+      "crystalCost": 3099
+    },
+    {
+      "level": 560,
+      "atkMultiplier": 12.872,
+      "hpMultiplier": 9.6613,
+      "defMultiplier": 7.048,
+      "goldCost": 8900000,
+      "crystalCost": 3109
+    },
+    {
+      "level": 561,
+      "atkMultiplier": 12.9044,
+      "hpMultiplier": 9.6843,
+      "defMultiplier": 7.0636,
+      "goldCost": 8930000,
+      "crystalCost": 3119
+    },
+    {
+      "level": 562,
+      "atkMultiplier": 12.9369,
+      "hpMultiplier": 9.7073,
+      "defMultiplier": 7.0792,
+      "goldCost": 8960000,
+      "crystalCost": 3129
+    },
+    {
+      "level": 563,
+      "atkMultiplier": 12.9694,
+      "hpMultiplier": 9.7303,
+      "defMultiplier": 7.0949,
+      "goldCost": 8990000,
+      "crystalCost": 3139
+    },
+    {
+      "level": 564,
+      "atkMultiplier": 13.0019,
+      "hpMultiplier": 9.7533,
+      "defMultiplier": 7.1105,
+      "goldCost": 9020000,
+      "crystalCost": 3149
+    },
+    {
+      "level": 565,
+      "atkMultiplier": 13.0345,
+      "hpMultiplier": 9.7763,
+      "defMultiplier": 7.1262,
+      "goldCost": 9050000,
+      "crystalCost": 3159
+    },
+    {
+      "level": 566,
+      "atkMultiplier": 13.0671,
+      "hpMultiplier": 9.7994,
+      "defMultiplier": 7.1419,
+      "goldCost": 9080000,
+      "crystalCost": 3169
+    },
+    {
+      "level": 567,
+      "atkMultiplier": 13.0998,
+      "hpMultiplier": 9.8225,
+      "defMultiplier": 7.1576,
+      "goldCost": 9110000,
+      "crystalCost": 3179
+    },
+    {
+      "level": 568,
+      "atkMultiplier": 13.1325,
+      "hpMultiplier": 9.8457,
+      "defMultiplier": 7.1733,
+      "goldCost": 9140000,
+      "crystalCost": 3189
+    },
+    {
+      "level": 569,
+      "atkMultiplier": 13.1652,
+      "hpMultiplier": 9.8688,
+      "defMultiplier": 7.1891,
+      "goldCost": 9170000,
+      "crystalCost": 3199
+    },
+    {
+      "level": 570,
+      "atkMultiplier": 13.198,
+      "hpMultiplier": 9.892,
+      "defMultiplier": 7.2049,
+      "goldCost": 9200000,
+      "crystalCost": 3209
+    },
+    {
+      "level": 571,
+      "atkMultiplier": 13.2308,
+      "hpMultiplier": 9.9152,
+      "defMultiplier": 7.2206,
+      "goldCost": 9230000,
+      "crystalCost": 3219
+    },
+    {
+      "level": 572,
+      "atkMultiplier": 13.2637,
+      "hpMultiplier": 9.9385,
+      "defMultiplier": 7.2364,
+      "goldCost": 9260000,
+      "crystalCost": 3229
+    },
+    {
+      "level": 573,
+      "atkMultiplier": 13.2966,
+      "hpMultiplier": 9.9617,
+      "defMultiplier": 7.2522,
+      "goldCost": 9290000,
+      "crystalCost": 3239
+    },
+    {
+      "level": 574,
+      "atkMultiplier": 13.3295,
+      "hpMultiplier": 9.985,
+      "defMultiplier": 7.2681,
+      "goldCost": 9320000,
+      "crystalCost": 3249
+    },
+    {
+      "level": 575,
+      "atkMultiplier": 13.3625,
+      "hpMultiplier": 10.0083,
+      "defMultiplier": 7.2839,
+      "goldCost": 9350000,
+      "crystalCost": 3259
+    },
+    {
+      "level": 576,
+      "atkMultiplier": 13.3955,
+      "hpMultiplier": 10.0317,
+      "defMultiplier": 7.2998,
+      "goldCost": 9380000,
+      "crystalCost": 3269
+    },
+    {
+      "level": 577,
+      "atkMultiplier": 13.4286,
+      "hpMultiplier": 10.0551,
+      "defMultiplier": 7.3157,
+      "goldCost": 9410000,
+      "crystalCost": 3279
+    },
+    {
+      "level": 578,
+      "atkMultiplier": 13.4617,
+      "hpMultiplier": 10.0785,
+      "defMultiplier": 7.3316,
+      "goldCost": 9440000,
+      "crystalCost": 3289
+    },
+    {
+      "level": 579,
+      "atkMultiplier": 13.4948,
+      "hpMultiplier": 10.1019,
+      "defMultiplier": 7.3475,
+      "goldCost": 9470000,
+      "crystalCost": 3299
+    },
+    {
+      "level": 580,
+      "atkMultiplier": 13.528,
+      "hpMultiplier": 10.1253,
+      "defMultiplier": 7.3634,
+      "goldCost": 9500000,
+      "crystalCost": 3309
+    },
+    {
+      "level": 581,
+      "atkMultiplier": 13.5612,
+      "hpMultiplier": 10.1488,
+      "defMultiplier": 7.3794,
+      "goldCost": 9530000,
+      "crystalCost": 3319
+    },
+    {
+      "level": 582,
+      "atkMultiplier": 13.5945,
+      "hpMultiplier": 10.1723,
+      "defMultiplier": 7.3953,
+      "goldCost": 9560000,
+      "crystalCost": 3329
+    },
+    {
+      "level": 583,
+      "atkMultiplier": 13.6278,
+      "hpMultiplier": 10.1959,
+      "defMultiplier": 7.4113,
+      "goldCost": 9590000,
+      "crystalCost": 3339
+    },
+    {
+      "level": 584,
+      "atkMultiplier": 13.6611,
+      "hpMultiplier": 10.2194,
+      "defMultiplier": 7.4273,
+      "goldCost": 9620000,
+      "crystalCost": 3349
+    },
+    {
+      "level": 585,
+      "atkMultiplier": 13.6945,
+      "hpMultiplier": 10.243,
+      "defMultiplier": 7.4434,
+      "goldCost": 9650000,
+      "crystalCost": 3359
+    },
+    {
+      "level": 586,
+      "atkMultiplier": 13.7279,
+      "hpMultiplier": 10.2666,
+      "defMultiplier": 7.4594,
+      "goldCost": 9680000,
+      "crystalCost": 3369
+    },
+    {
+      "level": 587,
+      "atkMultiplier": 13.7614,
+      "hpMultiplier": 10.2903,
+      "defMultiplier": 7.4754,
+      "goldCost": 9710000,
+      "crystalCost": 3379
+    },
+    {
+      "level": 588,
+      "atkMultiplier": 13.7949,
+      "hpMultiplier": 10.3139,
+      "defMultiplier": 7.4915,
+      "goldCost": 9740000,
+      "crystalCost": 3389
+    },
+    {
+      "level": 589,
+      "atkMultiplier": 13.8284,
+      "hpMultiplier": 10.3376,
+      "defMultiplier": 7.5076,
+      "goldCost": 9770000,
+      "crystalCost": 3399
+    },
+    {
+      "level": 590,
+      "atkMultiplier": 13.862,
+      "hpMultiplier": 10.3613,
+      "defMultiplier": 7.5237,
+      "goldCost": 9800000,
+      "crystalCost": 3409
+    },
+    {
+      "level": 591,
+      "atkMultiplier": 13.8956,
+      "hpMultiplier": 10.3851,
+      "defMultiplier": 7.5398,
+      "goldCost": 9830000,
+      "crystalCost": 3419
+    },
+    {
+      "level": 592,
+      "atkMultiplier": 13.9293,
+      "hpMultiplier": 10.4089,
+      "defMultiplier": 7.556,
+      "goldCost": 9860000,
+      "crystalCost": 3429
+    },
+    {
+      "level": 593,
+      "atkMultiplier": 13.963,
+      "hpMultiplier": 10.4327,
+      "defMultiplier": 7.5721,
+      "goldCost": 9890000,
+      "crystalCost": 3439
+    },
+    {
+      "level": 594,
+      "atkMultiplier": 13.9967,
+      "hpMultiplier": 10.4565,
+      "defMultiplier": 7.5883,
+      "goldCost": 9920000,
+      "crystalCost": 3449
+    },
+    {
+      "level": 595,
+      "atkMultiplier": 14.0305,
+      "hpMultiplier": 10.4803,
+      "defMultiplier": 7.6045,
+      "goldCost": 9950000,
+      "crystalCost": 3459
+    },
+    {
+      "level": 596,
+      "atkMultiplier": 14.0643,
+      "hpMultiplier": 10.5042,
+      "defMultiplier": 7.6207,
+      "goldCost": 9980000,
+      "crystalCost": 3469
+    },
+    {
+      "level": 597,
+      "atkMultiplier": 14.0982,
+      "hpMultiplier": 10.5281,
+      "defMultiplier": 7.6369,
+      "goldCost": 10010000,
+      "crystalCost": 3479
+    },
+    {
+      "level": 598,
+      "atkMultiplier": 14.1321,
+      "hpMultiplier": 10.5521,
+      "defMultiplier": 7.6532,
+      "goldCost": 10040000,
+      "crystalCost": 3489
+    },
+    {
+      "level": 599,
+      "atkMultiplier": 14.166,
+      "hpMultiplier": 10.576,
+      "defMultiplier": 7.6694,
+      "goldCost": 10070000,
+      "crystalCost": 3499
+    },
+    {
+      "level": 600,
+      "atkMultiplier": 14.2,
+      "hpMultiplier": 10.6,
+      "defMultiplier": 7.6857,
+      "goldCost": 10100000,
+      "crystalCost": 3509
+    },
+    {
+      "level": 601,
+      "atkMultiplier": 14.234,
+      "hpMultiplier": 10.624,
+      "defMultiplier": 7.702,
+      "goldCost": 10300000,
+      "crystalCost": 3559
+    },
+    {
+      "level": 602,
+      "atkMultiplier": 14.2681,
+      "hpMultiplier": 10.6481,
+      "defMultiplier": 7.7183,
+      "goldCost": 10500000,
+      "crystalCost": 3609
+    },
+    {
+      "level": 603,
+      "atkMultiplier": 14.3022,
+      "hpMultiplier": 10.6721,
+      "defMultiplier": 7.7346,
+      "goldCost": 10700000,
+      "crystalCost": 3659
+    },
+    {
+      "level": 604,
+      "atkMultiplier": 14.3363,
+      "hpMultiplier": 10.6962,
+      "defMultiplier": 7.751,
+      "goldCost": 10900000,
+      "crystalCost": 3709
+    },
+    {
+      "level": 605,
+      "atkMultiplier": 14.3705,
+      "hpMultiplier": 10.7203,
+      "defMultiplier": 7.7674,
+      "goldCost": 11100000,
+      "crystalCost": 3759
+    },
+    {
+      "level": 606,
+      "atkMultiplier": 14.4047,
+      "hpMultiplier": 10.7445,
+      "defMultiplier": 7.7837,
+      "goldCost": 11300000,
+      "crystalCost": 3809
+    },
+    {
+      "level": 607,
+      "atkMultiplier": 14.439,
+      "hpMultiplier": 10.7687,
+      "defMultiplier": 7.8001,
+      "goldCost": 11500000,
+      "crystalCost": 3859
+    },
+    {
+      "level": 608,
+      "atkMultiplier": 14.4733,
+      "hpMultiplier": 10.7929,
+      "defMultiplier": 7.8165,
+      "goldCost": 11700000,
+      "crystalCost": 3909
+    },
+    {
+      "level": 609,
+      "atkMultiplier": 14.5076,
+      "hpMultiplier": 10.8171,
+      "defMultiplier": 7.833,
+      "goldCost": 11900000,
+      "crystalCost": 3959
+    },
+    {
+      "level": 610,
+      "atkMultiplier": 14.542,
+      "hpMultiplier": 10.8413,
+      "defMultiplier": 7.8494,
+      "goldCost": 12100000,
+      "crystalCost": 4009
+    },
+    {
+      "level": 611,
+      "atkMultiplier": 14.5764,
+      "hpMultiplier": 10.8656,
+      "defMultiplier": 7.8659,
+      "goldCost": 12300000,
+      "crystalCost": 4059
+    },
+    {
+      "level": 612,
+      "atkMultiplier": 14.6109,
+      "hpMultiplier": 10.8899,
+      "defMultiplier": 7.8824,
+      "goldCost": 12500000,
+      "crystalCost": 4109
+    },
+    {
+      "level": 613,
+      "atkMultiplier": 14.6454,
+      "hpMultiplier": 10.9143,
+      "defMultiplier": 7.8989,
+      "goldCost": 12700000,
+      "crystalCost": 4159
+    },
+    {
+      "level": 614,
+      "atkMultiplier": 14.6799,
+      "hpMultiplier": 10.9386,
+      "defMultiplier": 7.9154,
+      "goldCost": 12900000,
+      "crystalCost": 4209
+    },
+    {
+      "level": 615,
+      "atkMultiplier": 14.7145,
+      "hpMultiplier": 10.963,
+      "defMultiplier": 7.9319,
+      "goldCost": 13100000,
+      "crystalCost": 4259
+    },
+    {
+      "level": 616,
+      "atkMultiplier": 14.7491,
+      "hpMultiplier": 10.9874,
+      "defMultiplier": 7.9485,
+      "goldCost": 13300000,
+      "crystalCost": 4309
+    },
+    {
+      "level": 617,
+      "atkMultiplier": 14.7838,
+      "hpMultiplier": 11.0119,
+      "defMultiplier": 7.965,
+      "goldCost": 13500000,
+      "crystalCost": 4359
+    },
+    {
+      "level": 618,
+      "atkMultiplier": 14.8185,
+      "hpMultiplier": 11.0363,
+      "defMultiplier": 7.9816,
+      "goldCost": 13700000,
+      "crystalCost": 4409
+    },
+    {
+      "level": 619,
+      "atkMultiplier": 14.8532,
+      "hpMultiplier": 11.0608,
+      "defMultiplier": 7.9982,
+      "goldCost": 13900000,
+      "crystalCost": 4459
+    },
+    {
+      "level": 620,
+      "atkMultiplier": 14.888,
+      "hpMultiplier": 11.0853,
+      "defMultiplier": 8.0149,
+      "goldCost": 14100000,
+      "crystalCost": 4509
+    },
+    {
+      "level": 621,
+      "atkMultiplier": 14.9228,
+      "hpMultiplier": 11.1099,
+      "defMultiplier": 8.0315,
+      "goldCost": 14300000,
+      "crystalCost": 4559
+    },
+    {
+      "level": 622,
+      "atkMultiplier": 14.9577,
+      "hpMultiplier": 11.1345,
+      "defMultiplier": 8.0481,
+      "goldCost": 14500000,
+      "crystalCost": 4609
+    },
+    {
+      "level": 623,
+      "atkMultiplier": 14.9926,
+      "hpMultiplier": 11.1591,
+      "defMultiplier": 8.0648,
+      "goldCost": 14700000,
+      "crystalCost": 4659
+    },
+    {
+      "level": 624,
+      "atkMultiplier": 15.0275,
+      "hpMultiplier": 11.1837,
+      "defMultiplier": 8.0815,
+      "goldCost": 14900000,
+      "crystalCost": 4709
+    },
+    {
+      "level": 625,
+      "atkMultiplier": 15.0625,
+      "hpMultiplier": 11.2083,
+      "defMultiplier": 8.0982,
+      "goldCost": 15100000,
+      "crystalCost": 4759
+    },
+    {
+      "level": 626,
+      "atkMultiplier": 15.0975,
+      "hpMultiplier": 11.233,
+      "defMultiplier": 8.1149,
+      "goldCost": 15300000,
+      "crystalCost": 4809
+    },
+    {
+      "level": 627,
+      "atkMultiplier": 15.1326,
+      "hpMultiplier": 11.2577,
+      "defMultiplier": 8.1317,
+      "goldCost": 15500000,
+      "crystalCost": 4859
+    },
+    {
+      "level": 628,
+      "atkMultiplier": 15.1677,
+      "hpMultiplier": 11.2825,
+      "defMultiplier": 8.1484,
+      "goldCost": 15700000,
+      "crystalCost": 4909
+    },
+    {
+      "level": 629,
+      "atkMultiplier": 15.2028,
+      "hpMultiplier": 11.3072,
+      "defMultiplier": 8.1652,
+      "goldCost": 15900000,
+      "crystalCost": 4959
+    },
+    {
+      "level": 630,
+      "atkMultiplier": 15.238,
+      "hpMultiplier": 11.332,
+      "defMultiplier": 8.182,
+      "goldCost": 16100000,
+      "crystalCost": 5009
+    },
+    {
+      "level": 631,
+      "atkMultiplier": 15.2732,
+      "hpMultiplier": 11.3568,
+      "defMultiplier": 8.1988,
+      "goldCost": 16300000,
+      "crystalCost": 5059
+    },
+    {
+      "level": 632,
+      "atkMultiplier": 15.3085,
+      "hpMultiplier": 11.3817,
+      "defMultiplier": 8.2156,
+      "goldCost": 16500000,
+      "crystalCost": 5109
+    },
+    {
+      "level": 633,
+      "atkMultiplier": 15.3438,
+      "hpMultiplier": 11.4065,
+      "defMultiplier": 8.2325,
+      "goldCost": 16700000,
+      "crystalCost": 5159
+    },
+    {
+      "level": 634,
+      "atkMultiplier": 15.3791,
+      "hpMultiplier": 11.4314,
+      "defMultiplier": 8.2493,
+      "goldCost": 16900000,
+      "crystalCost": 5209
+    },
+    {
+      "level": 635,
+      "atkMultiplier": 15.4145,
+      "hpMultiplier": 11.4563,
+      "defMultiplier": 8.2662,
+      "goldCost": 17100000,
+      "crystalCost": 5259
+    },
+    {
+      "level": 636,
+      "atkMultiplier": 15.4499,
+      "hpMultiplier": 11.4813,
+      "defMultiplier": 8.2831,
+      "goldCost": 17300000,
+      "crystalCost": 5309
+    },
+    {
+      "level": 637,
+      "atkMultiplier": 15.4854,
+      "hpMultiplier": 11.5063,
+      "defMultiplier": 8.3,
+      "goldCost": 17500000,
+      "crystalCost": 5359
+    },
+    {
+      "level": 638,
+      "atkMultiplier": 15.5209,
+      "hpMultiplier": 11.5313,
+      "defMultiplier": 8.3169,
+      "goldCost": 17700000,
+      "crystalCost": 5409
+    },
+    {
+      "level": 639,
+      "atkMultiplier": 15.5564,
+      "hpMultiplier": 11.5563,
+      "defMultiplier": 8.3339,
+      "goldCost": 17900000,
+      "crystalCost": 5459
+    },
+    {
+      "level": 640,
+      "atkMultiplier": 15.592,
+      "hpMultiplier": 11.5813,
+      "defMultiplier": 8.3509,
+      "goldCost": 18100000,
+      "crystalCost": 5509
+    },
+    {
+      "level": 641,
+      "atkMultiplier": 15.6276,
+      "hpMultiplier": 11.6064,
+      "defMultiplier": 8.3678,
+      "goldCost": 18300000,
+      "crystalCost": 5559
+    },
+    {
+      "level": 642,
+      "atkMultiplier": 15.6633,
+      "hpMultiplier": 11.6315,
+      "defMultiplier": 8.3848,
+      "goldCost": 18500000,
+      "crystalCost": 5609
+    },
+    {
+      "level": 643,
+      "atkMultiplier": 15.699,
+      "hpMultiplier": 11.6567,
+      "defMultiplier": 8.4018,
+      "goldCost": 18700000,
+      "crystalCost": 5659
+    },
+    {
+      "level": 644,
+      "atkMultiplier": 15.7347,
+      "hpMultiplier": 11.6818,
+      "defMultiplier": 8.4189,
+      "goldCost": 18900000,
+      "crystalCost": 5709
+    },
+    {
+      "level": 645,
+      "atkMultiplier": 15.7705,
+      "hpMultiplier": 11.707,
+      "defMultiplier": 8.4359,
+      "goldCost": 19100000,
+      "crystalCost": 5759
+    },
+    {
+      "level": 646,
+      "atkMultiplier": 15.8063,
+      "hpMultiplier": 11.7322,
+      "defMultiplier": 8.453,
+      "goldCost": 19300000,
+      "crystalCost": 5809
+    },
+    {
+      "level": 647,
+      "atkMultiplier": 15.8422,
+      "hpMultiplier": 11.7575,
+      "defMultiplier": 8.4701,
+      "goldCost": 19500000,
+      "crystalCost": 5859
+    },
+    {
+      "level": 648,
+      "atkMultiplier": 15.8781,
+      "hpMultiplier": 11.7827,
+      "defMultiplier": 8.4872,
+      "goldCost": 19700000,
+      "crystalCost": 5909
+    },
+    {
+      "level": 649,
+      "atkMultiplier": 15.914,
+      "hpMultiplier": 11.808,
+      "defMultiplier": 8.5043,
+      "goldCost": 19900000,
+      "crystalCost": 5959
+    },
+    {
+      "level": 650,
+      "atkMultiplier": 15.95,
+      "hpMultiplier": 11.8333,
+      "defMultiplier": 8.5214,
+      "goldCost": 20100000,
+      "crystalCost": 6009
+    },
+    {
+      "level": 651,
+      "atkMultiplier": 15.986,
+      "hpMultiplier": 11.8587,
+      "defMultiplier": 8.5386,
+      "goldCost": 20300000,
+      "crystalCost": 6059
+    },
+    {
+      "level": 652,
+      "atkMultiplier": 16.0221,
+      "hpMultiplier": 11.8841,
+      "defMultiplier": 8.5557,
+      "goldCost": 20500000,
+      "crystalCost": 6109
+    },
+    {
+      "level": 653,
+      "atkMultiplier": 16.0582,
+      "hpMultiplier": 11.9095,
+      "defMultiplier": 8.5729,
+      "goldCost": 20700000,
+      "crystalCost": 6159
+    },
+    {
+      "level": 654,
+      "atkMultiplier": 16.0943,
+      "hpMultiplier": 11.9349,
+      "defMultiplier": 8.5901,
+      "goldCost": 20900000,
+      "crystalCost": 6209
+    },
+    {
+      "level": 655,
+      "atkMultiplier": 16.1305,
+      "hpMultiplier": 11.9603,
+      "defMultiplier": 8.6074,
+      "goldCost": 21100000,
+      "crystalCost": 6259
+    },
+    {
+      "level": 656,
+      "atkMultiplier": 16.1667,
+      "hpMultiplier": 11.9858,
+      "defMultiplier": 8.6246,
+      "goldCost": 21300000,
+      "crystalCost": 6309
+    },
+    {
+      "level": 657,
+      "atkMultiplier": 16.203,
+      "hpMultiplier": 12.0113,
+      "defMultiplier": 8.6418,
+      "goldCost": 21500000,
+      "crystalCost": 6359
+    },
+    {
+      "level": 658,
+      "atkMultiplier": 16.2393,
+      "hpMultiplier": 12.0369,
+      "defMultiplier": 8.6591,
+      "goldCost": 21700000,
+      "crystalCost": 6409
+    },
+    {
+      "level": 659,
+      "atkMultiplier": 16.2756,
+      "hpMultiplier": 12.0624,
+      "defMultiplier": 8.6764,
+      "goldCost": 21900000,
+      "crystalCost": 6459
+    },
+    {
+      "level": 660,
+      "atkMultiplier": 16.312,
+      "hpMultiplier": 12.088,
+      "defMultiplier": 8.6937,
+      "goldCost": 22100000,
+      "crystalCost": 6509
+    },
+    {
+      "level": 661,
+      "atkMultiplier": 16.3484,
+      "hpMultiplier": 12.1136,
+      "defMultiplier": 8.711,
+      "goldCost": 22300000,
+      "crystalCost": 6559
+    },
+    {
+      "level": 662,
+      "atkMultiplier": 16.3849,
+      "hpMultiplier": 12.1393,
+      "defMultiplier": 8.7284,
+      "goldCost": 22500000,
+      "crystalCost": 6609
+    },
+    {
+      "level": 663,
+      "atkMultiplier": 16.4214,
+      "hpMultiplier": 12.1649,
+      "defMultiplier": 8.7457,
+      "goldCost": 22700000,
+      "crystalCost": 6659
+    },
+    {
+      "level": 664,
+      "atkMultiplier": 16.4579,
+      "hpMultiplier": 12.1906,
+      "defMultiplier": 8.7631,
+      "goldCost": 22900000,
+      "crystalCost": 6709
+    },
+    {
+      "level": 665,
+      "atkMultiplier": 16.4945,
+      "hpMultiplier": 12.2163,
+      "defMultiplier": 8.7805,
+      "goldCost": 23100000,
+      "crystalCost": 6759
+    },
+    {
+      "level": 666,
+      "atkMultiplier": 16.5311,
+      "hpMultiplier": 12.2421,
+      "defMultiplier": 8.7979,
+      "goldCost": 23300000,
+      "crystalCost": 6809
+    },
+    {
+      "level": 667,
+      "atkMultiplier": 16.5678,
+      "hpMultiplier": 12.2679,
+      "defMultiplier": 8.8153,
+      "goldCost": 23500000,
+      "crystalCost": 6859
+    },
+    {
+      "level": 668,
+      "atkMultiplier": 16.6045,
+      "hpMultiplier": 12.2937,
+      "defMultiplier": 8.8328,
+      "goldCost": 23700000,
+      "crystalCost": 6909
+    },
+    {
+      "level": 669,
+      "atkMultiplier": 16.6412,
+      "hpMultiplier": 12.3195,
+      "defMultiplier": 8.8502,
+      "goldCost": 23900000,
+      "crystalCost": 6959
+    },
+    {
+      "level": 670,
+      "atkMultiplier": 16.678,
+      "hpMultiplier": 12.3453,
+      "defMultiplier": 8.8677,
+      "goldCost": 24100000,
+      "crystalCost": 7009
+    },
+    {
+      "level": 671,
+      "atkMultiplier": 16.7148,
+      "hpMultiplier": 12.3712,
+      "defMultiplier": 8.8852,
+      "goldCost": 24300000,
+      "crystalCost": 7059
+    },
+    {
+      "level": 672,
+      "atkMultiplier": 16.7517,
+      "hpMultiplier": 12.3971,
+      "defMultiplier": 8.9027,
+      "goldCost": 24500000,
+      "crystalCost": 7109
+    },
+    {
+      "level": 673,
+      "atkMultiplier": 16.7886,
+      "hpMultiplier": 12.4231,
+      "defMultiplier": 8.9202,
+      "goldCost": 24700000,
+      "crystalCost": 7159
+    },
+    {
+      "level": 674,
+      "atkMultiplier": 16.8255,
+      "hpMultiplier": 12.449,
+      "defMultiplier": 8.9378,
+      "goldCost": 24900000,
+      "crystalCost": 7209
+    },
+    {
+      "level": 675,
+      "atkMultiplier": 16.8625,
+      "hpMultiplier": 12.475,
+      "defMultiplier": 8.9554,
+      "goldCost": 25100000,
+      "crystalCost": 7259
+    },
+    {
+      "level": 676,
+      "atkMultiplier": 16.8995,
+      "hpMultiplier": 12.501,
+      "defMultiplier": 8.9729,
+      "goldCost": 25300000,
+      "crystalCost": 7309
+    },
+    {
+      "level": 677,
+      "atkMultiplier": 16.9366,
+      "hpMultiplier": 12.5271,
+      "defMultiplier": 8.9905,
+      "goldCost": 25500000,
+      "crystalCost": 7359
+    },
+    {
+      "level": 678,
+      "atkMultiplier": 16.9737,
+      "hpMultiplier": 12.5531,
+      "defMultiplier": 9.0081,
+      "goldCost": 25700000,
+      "crystalCost": 7409
+    },
+    {
+      "level": 679,
+      "atkMultiplier": 17.0108,
+      "hpMultiplier": 12.5792,
+      "defMultiplier": 9.0258,
+      "goldCost": 25900000,
+      "crystalCost": 7459
+    },
+    {
+      "level": 680,
+      "atkMultiplier": 17.048,
+      "hpMultiplier": 12.6053,
+      "defMultiplier": 9.0434,
+      "goldCost": 26100000,
+      "crystalCost": 7509
+    },
+    {
+      "level": 681,
+      "atkMultiplier": 17.0852,
+      "hpMultiplier": 12.6315,
+      "defMultiplier": 9.0611,
+      "goldCost": 26300000,
+      "crystalCost": 7559
+    },
+    {
+      "level": 682,
+      "atkMultiplier": 17.1225,
+      "hpMultiplier": 12.6577,
+      "defMultiplier": 9.0788,
+      "goldCost": 26500000,
+      "crystalCost": 7609
+    },
+    {
+      "level": 683,
+      "atkMultiplier": 17.1598,
+      "hpMultiplier": 12.6839,
+      "defMultiplier": 9.0965,
+      "goldCost": 26700000,
+      "crystalCost": 7659
+    },
+    {
+      "level": 684,
+      "atkMultiplier": 17.1971,
+      "hpMultiplier": 12.7101,
+      "defMultiplier": 9.1142,
+      "goldCost": 26900000,
+      "crystalCost": 7709
+    },
+    {
+      "level": 685,
+      "atkMultiplier": 17.2345,
+      "hpMultiplier": 12.7363,
+      "defMultiplier": 9.1319,
+      "goldCost": 27100000,
+      "crystalCost": 7759
+    },
+    {
+      "level": 686,
+      "atkMultiplier": 17.2719,
+      "hpMultiplier": 12.7626,
+      "defMultiplier": 9.1497,
+      "goldCost": 27300000,
+      "crystalCost": 7809
+    },
+    {
+      "level": 687,
+      "atkMultiplier": 17.3094,
+      "hpMultiplier": 12.7889,
+      "defMultiplier": 9.1674,
+      "goldCost": 27500000,
+      "crystalCost": 7859
+    },
+    {
+      "level": 688,
+      "atkMultiplier": 17.3469,
+      "hpMultiplier": 12.8153,
+      "defMultiplier": 9.1852,
+      "goldCost": 27700000,
+      "crystalCost": 7909
+    },
+    {
+      "level": 689,
+      "atkMultiplier": 17.3844,
+      "hpMultiplier": 12.8416,
+      "defMultiplier": 9.203,
+      "goldCost": 27900000,
+      "crystalCost": 7959
+    },
+    {
+      "level": 690,
+      "atkMultiplier": 17.422,
+      "hpMultiplier": 12.868,
+      "defMultiplier": 9.2209,
+      "goldCost": 28100000,
+      "crystalCost": 8009
+    },
+    {
+      "level": 691,
+      "atkMultiplier": 17.4596,
+      "hpMultiplier": 12.8944,
+      "defMultiplier": 9.2387,
+      "goldCost": 28300000,
+      "crystalCost": 8059
+    },
+    {
+      "level": 692,
+      "atkMultiplier": 17.4973,
+      "hpMultiplier": 12.9209,
+      "defMultiplier": 9.2565,
+      "goldCost": 28500000,
+      "crystalCost": 8109
+    },
+    {
+      "level": 693,
+      "atkMultiplier": 17.535,
+      "hpMultiplier": 12.9473,
+      "defMultiplier": 9.2744,
+      "goldCost": 28700000,
+      "crystalCost": 8159
+    },
+    {
+      "level": 694,
+      "atkMultiplier": 17.5727,
+      "hpMultiplier": 12.9738,
+      "defMultiplier": 9.2923,
+      "goldCost": 28900000,
+      "crystalCost": 8209
+    },
+    {
+      "level": 695,
+      "atkMultiplier": 17.6105,
+      "hpMultiplier": 13.0003,
+      "defMultiplier": 9.3102,
+      "goldCost": 29100000,
+      "crystalCost": 8259
+    },
+    {
+      "level": 696,
+      "atkMultiplier": 17.6483,
+      "hpMultiplier": 13.0269,
+      "defMultiplier": 9.3281,
+      "goldCost": 29300000,
+      "crystalCost": 8309
+    },
+    {
+      "level": 697,
+      "atkMultiplier": 17.6862,
+      "hpMultiplier": 13.0535,
+      "defMultiplier": 9.3461,
+      "goldCost": 29500000,
+      "crystalCost": 8359
+    },
+    {
+      "level": 698,
+      "atkMultiplier": 17.7241,
+      "hpMultiplier": 13.0801,
+      "defMultiplier": 9.364,
+      "goldCost": 29700000,
+      "crystalCost": 8409
+    },
+    {
+      "level": 699,
+      "atkMultiplier": 17.762,
+      "hpMultiplier": 13.1067,
+      "defMultiplier": 9.382,
+      "goldCost": 29900000,
+      "crystalCost": 8459
+    },
+    {
+      "level": 700,
+      "atkMultiplier": 17.8,
+      "hpMultiplier": 13.1333,
+      "defMultiplier": 9.4,
+      "goldCost": 30100000,
+      "crystalCost": 8509
+    },
+    {
+      "level": 701,
+      "atkMultiplier": 17.838,
+      "hpMultiplier": 13.16,
+      "defMultiplier": 9.418,
+      "goldCost": 30300000,
+      "crystalCost": 8559
+    },
+    {
+      "level": 702,
+      "atkMultiplier": 17.8761,
+      "hpMultiplier": 13.1867,
+      "defMultiplier": 9.436,
+      "goldCost": 30500000,
+      "crystalCost": 8609
+    },
+    {
+      "level": 703,
+      "atkMultiplier": 17.9142,
+      "hpMultiplier": 13.2135,
+      "defMultiplier": 9.4541,
+      "goldCost": 30700000,
+      "crystalCost": 8659
+    },
+    {
+      "level": 704,
+      "atkMultiplier": 17.9523,
+      "hpMultiplier": 13.2402,
+      "defMultiplier": 9.4721,
+      "goldCost": 30900000,
+      "crystalCost": 8709
+    },
+    {
+      "level": 705,
+      "atkMultiplier": 17.9905,
+      "hpMultiplier": 13.267,
+      "defMultiplier": 9.4902,
+      "goldCost": 31100000,
+      "crystalCost": 8759
+    },
+    {
+      "level": 706,
+      "atkMultiplier": 18.0287,
+      "hpMultiplier": 13.2938,
+      "defMultiplier": 9.5083,
+      "goldCost": 31300000,
+      "crystalCost": 8809
+    },
+    {
+      "level": 707,
+      "atkMultiplier": 18.067,
+      "hpMultiplier": 13.3207,
+      "defMultiplier": 9.5264,
+      "goldCost": 31500000,
+      "crystalCost": 8859
+    },
+    {
+      "level": 708,
+      "atkMultiplier": 18.1053,
+      "hpMultiplier": 13.3475,
+      "defMultiplier": 9.5445,
+      "goldCost": 31700000,
+      "crystalCost": 8909
+    },
+    {
+      "level": 709,
+      "atkMultiplier": 18.1436,
+      "hpMultiplier": 13.3744,
+      "defMultiplier": 9.5627,
+      "goldCost": 31900000,
+      "crystalCost": 8959
+    },
+    {
+      "level": 710,
+      "atkMultiplier": 18.182,
+      "hpMultiplier": 13.4013,
+      "defMultiplier": 9.5809,
+      "goldCost": 32100000,
+      "crystalCost": 9009
+    },
+    {
+      "level": 711,
+      "atkMultiplier": 18.2204,
+      "hpMultiplier": 13.4283,
+      "defMultiplier": 9.599,
+      "goldCost": 32300000,
+      "crystalCost": 9059
+    },
+    {
+      "level": 712,
+      "atkMultiplier": 18.2589,
+      "hpMultiplier": 13.4553,
+      "defMultiplier": 9.6172,
+      "goldCost": 32500000,
+      "crystalCost": 9109
+    },
+    {
+      "level": 713,
+      "atkMultiplier": 18.2974,
+      "hpMultiplier": 13.4823,
+      "defMultiplier": 9.6354,
+      "goldCost": 32700000,
+      "crystalCost": 9159
+    },
+    {
+      "level": 714,
+      "atkMultiplier": 18.3359,
+      "hpMultiplier": 13.5093,
+      "defMultiplier": 9.6537,
+      "goldCost": 32900000,
+      "crystalCost": 9209
+    },
+    {
+      "level": 715,
+      "atkMultiplier": 18.3745,
+      "hpMultiplier": 13.5363,
+      "defMultiplier": 9.6719,
+      "goldCost": 33100000,
+      "crystalCost": 9259
+    },
+    {
+      "level": 716,
+      "atkMultiplier": 18.4131,
+      "hpMultiplier": 13.5634,
+      "defMultiplier": 9.6902,
+      "goldCost": 33300000,
+      "crystalCost": 9309
+    },
+    {
+      "level": 717,
+      "atkMultiplier": 18.4518,
+      "hpMultiplier": 13.5905,
+      "defMultiplier": 9.7085,
+      "goldCost": 33500000,
+      "crystalCost": 9359
+    },
+    {
+      "level": 718,
+      "atkMultiplier": 18.4905,
+      "hpMultiplier": 13.6177,
+      "defMultiplier": 9.7268,
+      "goldCost": 33700000,
+      "crystalCost": 9409
+    },
+    {
+      "level": 719,
+      "atkMultiplier": 18.5292,
+      "hpMultiplier": 13.6448,
+      "defMultiplier": 9.7451,
+      "goldCost": 33900000,
+      "crystalCost": 9459
+    },
+    {
+      "level": 720,
+      "atkMultiplier": 18.568,
+      "hpMultiplier": 13.672,
+      "defMultiplier": 9.7634,
+      "goldCost": 34100000,
+      "crystalCost": 9509
+    },
+    {
+      "level": 721,
+      "atkMultiplier": 18.6068,
+      "hpMultiplier": 13.6992,
+      "defMultiplier": 9.7818,
+      "goldCost": 34300000,
+      "crystalCost": 9559
+    },
+    {
+      "level": 722,
+      "atkMultiplier": 18.6457,
+      "hpMultiplier": 13.7265,
+      "defMultiplier": 9.8001,
+      "goldCost": 34500000,
+      "crystalCost": 9609
+    },
+    {
+      "level": 723,
+      "atkMultiplier": 18.6846,
+      "hpMultiplier": 13.7537,
+      "defMultiplier": 9.8185,
+      "goldCost": 34700000,
+      "crystalCost": 9659
+    },
+    {
+      "level": 724,
+      "atkMultiplier": 18.7235,
+      "hpMultiplier": 13.781,
+      "defMultiplier": 9.8369,
+      "goldCost": 34900000,
+      "crystalCost": 9709
+    },
+    {
+      "level": 725,
+      "atkMultiplier": 18.7625,
+      "hpMultiplier": 13.8083,
+      "defMultiplier": 9.8554,
+      "goldCost": 35100000,
+      "crystalCost": 9759
+    },
+    {
+      "level": 726,
+      "atkMultiplier": 18.8015,
+      "hpMultiplier": 13.8357,
+      "defMultiplier": 9.8738,
+      "goldCost": 35300000,
+      "crystalCost": 9809
+    },
+    {
+      "level": 727,
+      "atkMultiplier": 18.8406,
+      "hpMultiplier": 13.8631,
+      "defMultiplier": 9.8922,
+      "goldCost": 35500000,
+      "crystalCost": 9859
+    },
+    {
+      "level": 728,
+      "atkMultiplier": 18.8797,
+      "hpMultiplier": 13.8905,
+      "defMultiplier": 9.9107,
+      "goldCost": 35700000,
+      "crystalCost": 9909
+    },
+    {
+      "level": 729,
+      "atkMultiplier": 18.9188,
+      "hpMultiplier": 13.9179,
+      "defMultiplier": 9.9292,
+      "goldCost": 35900000,
+      "crystalCost": 9959
+    },
+    {
+      "level": 730,
+      "atkMultiplier": 18.958,
+      "hpMultiplier": 13.9453,
+      "defMultiplier": 9.9477,
+      "goldCost": 36100000,
+      "crystalCost": 10009
+    },
+    {
+      "level": 731,
+      "atkMultiplier": 18.9972,
+      "hpMultiplier": 13.9728,
+      "defMultiplier": 9.9662,
+      "goldCost": 36300000,
+      "crystalCost": 10059
+    },
+    {
+      "level": 732,
+      "atkMultiplier": 19.0365,
+      "hpMultiplier": 14.0003,
+      "defMultiplier": 9.9848,
+      "goldCost": 36500000,
+      "crystalCost": 10109
+    },
+    {
+      "level": 733,
+      "atkMultiplier": 19.0758,
+      "hpMultiplier": 14.0279,
+      "defMultiplier": 10.0033,
+      "goldCost": 36700000,
+      "crystalCost": 10159
+    },
+    {
+      "level": 734,
+      "atkMultiplier": 19.1151,
+      "hpMultiplier": 14.0554,
+      "defMultiplier": 10.0219,
+      "goldCost": 36900000,
+      "crystalCost": 10209
+    },
+    {
+      "level": 735,
+      "atkMultiplier": 19.1545,
+      "hpMultiplier": 14.083,
+      "defMultiplier": 10.0405,
+      "goldCost": 37100000,
+      "crystalCost": 10259
+    },
+    {
+      "level": 736,
+      "atkMultiplier": 19.1939,
+      "hpMultiplier": 14.1106,
+      "defMultiplier": 10.0591,
+      "goldCost": 37300000,
+      "crystalCost": 10309
+    },
+    {
+      "level": 737,
+      "atkMultiplier": 19.2334,
+      "hpMultiplier": 14.1383,
+      "defMultiplier": 10.0777,
+      "goldCost": 37500000,
+      "crystalCost": 10359
+    },
+    {
+      "level": 738,
+      "atkMultiplier": 19.2729,
+      "hpMultiplier": 14.1659,
+      "defMultiplier": 10.0964,
+      "goldCost": 37700000,
+      "crystalCost": 10409
+    },
+    {
+      "level": 739,
+      "atkMultiplier": 19.3124,
+      "hpMultiplier": 14.1936,
+      "defMultiplier": 10.115,
+      "goldCost": 37900000,
+      "crystalCost": 10459
+    },
+    {
+      "level": 740,
+      "atkMultiplier": 19.352,
+      "hpMultiplier": 14.2213,
+      "defMultiplier": 10.1337,
+      "goldCost": 38100000,
+      "crystalCost": 10509
+    },
+    {
+      "level": 741,
+      "atkMultiplier": 19.3916,
+      "hpMultiplier": 14.2491,
+      "defMultiplier": 10.1524,
+      "goldCost": 38300000,
+      "crystalCost": 10559
+    },
+    {
+      "level": 742,
+      "atkMultiplier": 19.4313,
+      "hpMultiplier": 14.2769,
+      "defMultiplier": 10.1711,
+      "goldCost": 38500000,
+      "crystalCost": 10609
+    },
+    {
+      "level": 743,
+      "atkMultiplier": 19.471,
+      "hpMultiplier": 14.3047,
+      "defMultiplier": 10.1898,
+      "goldCost": 38700000,
+      "crystalCost": 10659
+    },
+    {
+      "level": 744,
+      "atkMultiplier": 19.5107,
+      "hpMultiplier": 14.3325,
+      "defMultiplier": 10.2086,
+      "goldCost": 38900000,
+      "crystalCost": 10709
+    },
+    {
+      "level": 745,
+      "atkMultiplier": 19.5505,
+      "hpMultiplier": 14.3603,
+      "defMultiplier": 10.2274,
+      "goldCost": 39100000,
+      "crystalCost": 10759
+    },
+    {
+      "level": 746,
+      "atkMultiplier": 19.5903,
+      "hpMultiplier": 14.3882,
+      "defMultiplier": 10.2461,
+      "goldCost": 39300000,
+      "crystalCost": 10809
+    },
+    {
+      "level": 747,
+      "atkMultiplier": 19.6302,
+      "hpMultiplier": 14.4161,
+      "defMultiplier": 10.2649,
+      "goldCost": 39500000,
+      "crystalCost": 10859
+    },
+    {
+      "level": 748,
+      "atkMultiplier": 19.6701,
+      "hpMultiplier": 14.4441,
+      "defMultiplier": 10.2837,
+      "goldCost": 39700000,
+      "crystalCost": 10909
+    },
+    {
+      "level": 749,
+      "atkMultiplier": 19.71,
+      "hpMultiplier": 14.472,
+      "defMultiplier": 10.3026,
+      "goldCost": 39900000,
+      "crystalCost": 10959
+    },
+    {
+      "level": 750,
+      "atkMultiplier": 19.75,
+      "hpMultiplier": 14.5,
+      "defMultiplier": 10.3214,
+      "goldCost": 40100000,
+      "crystalCost": 11009
+    },
+    {
+      "level": 751,
+      "atkMultiplier": 19.79,
+      "hpMultiplier": 14.528,
+      "defMultiplier": 10.3403,
+      "goldCost": 40300000,
+      "crystalCost": 11059
+    },
+    {
+      "level": 752,
+      "atkMultiplier": 19.8301,
+      "hpMultiplier": 14.5561,
+      "defMultiplier": 10.3592,
+      "goldCost": 40500000,
+      "crystalCost": 11109
+    },
+    {
+      "level": 753,
+      "atkMultiplier": 19.8702,
+      "hpMultiplier": 14.5841,
+      "defMultiplier": 10.3781,
+      "goldCost": 40700000,
+      "crystalCost": 11159
+    },
+    {
+      "level": 754,
+      "atkMultiplier": 19.9103,
+      "hpMultiplier": 14.6122,
+      "defMultiplier": 10.397,
+      "goldCost": 40900000,
+      "crystalCost": 11209
+    },
+    {
+      "level": 755,
+      "atkMultiplier": 19.9505,
+      "hpMultiplier": 14.6403,
+      "defMultiplier": 10.4159,
+      "goldCost": 41100000,
+      "crystalCost": 11259
+    },
+    {
+      "level": 756,
+      "atkMultiplier": 19.9907,
+      "hpMultiplier": 14.6685,
+      "defMultiplier": 10.4349,
+      "goldCost": 41300000,
+      "crystalCost": 11309
+    },
+    {
+      "level": 757,
+      "atkMultiplier": 20.031,
+      "hpMultiplier": 14.6967,
+      "defMultiplier": 10.4538,
+      "goldCost": 41500000,
+      "crystalCost": 11359
+    },
+    {
+      "level": 758,
+      "atkMultiplier": 20.0713,
+      "hpMultiplier": 14.7249,
+      "defMultiplier": 10.4728,
+      "goldCost": 41700000,
+      "crystalCost": 11409
+    },
+    {
+      "level": 759,
+      "atkMultiplier": 20.1116,
+      "hpMultiplier": 14.7531,
+      "defMultiplier": 10.4918,
+      "goldCost": 41900000,
+      "crystalCost": 11459
+    },
+    {
+      "level": 760,
+      "atkMultiplier": 20.152,
+      "hpMultiplier": 14.7813,
+      "defMultiplier": 10.5109,
+      "goldCost": 42100000,
+      "crystalCost": 11509
+    },
+    {
+      "level": 761,
+      "atkMultiplier": 20.1924,
+      "hpMultiplier": 14.8096,
+      "defMultiplier": 10.5299,
+      "goldCost": 42300000,
+      "crystalCost": 11559
+    },
+    {
+      "level": 762,
+      "atkMultiplier": 20.2329,
+      "hpMultiplier": 14.8379,
+      "defMultiplier": 10.5489,
+      "goldCost": 42500000,
+      "crystalCost": 11609
+    },
+    {
+      "level": 763,
+      "atkMultiplier": 20.2734,
+      "hpMultiplier": 14.8663,
+      "defMultiplier": 10.568,
+      "goldCost": 42700000,
+      "crystalCost": 11659
+    },
+    {
+      "level": 764,
+      "atkMultiplier": 20.3139,
+      "hpMultiplier": 14.8946,
+      "defMultiplier": 10.5871,
+      "goldCost": 42900000,
+      "crystalCost": 11709
+    },
+    {
+      "level": 765,
+      "atkMultiplier": 20.3545,
+      "hpMultiplier": 14.923,
+      "defMultiplier": 10.6062,
+      "goldCost": 43100000,
+      "crystalCost": 11759
+    },
+    {
+      "level": 766,
+      "atkMultiplier": 20.3951,
+      "hpMultiplier": 14.9514,
+      "defMultiplier": 10.6253,
+      "goldCost": 43300000,
+      "crystalCost": 11809
+    },
+    {
+      "level": 767,
+      "atkMultiplier": 20.4358,
+      "hpMultiplier": 14.9799,
+      "defMultiplier": 10.6445,
+      "goldCost": 43500000,
+      "crystalCost": 11859
+    },
+    {
+      "level": 768,
+      "atkMultiplier": 20.4765,
+      "hpMultiplier": 15.0083,
+      "defMultiplier": 10.6636,
+      "goldCost": 43700000,
+      "crystalCost": 11909
+    },
+    {
+      "level": 769,
+      "atkMultiplier": 20.5172,
+      "hpMultiplier": 15.0368,
+      "defMultiplier": 10.6828,
+      "goldCost": 43900000,
+      "crystalCost": 11959
+    },
+    {
+      "level": 770,
+      "atkMultiplier": 20.558,
+      "hpMultiplier": 15.0653,
+      "defMultiplier": 10.702,
+      "goldCost": 44100000,
+      "crystalCost": 12009
+    },
+    {
+      "level": 771,
+      "atkMultiplier": 20.5988,
+      "hpMultiplier": 15.0939,
+      "defMultiplier": 10.7212,
+      "goldCost": 44300000,
+      "crystalCost": 12059
+    },
+    {
+      "level": 772,
+      "atkMultiplier": 20.6397,
+      "hpMultiplier": 15.1225,
+      "defMultiplier": 10.7404,
+      "goldCost": 44500000,
+      "crystalCost": 12109
+    },
+    {
+      "level": 773,
+      "atkMultiplier": 20.6806,
+      "hpMultiplier": 15.1511,
+      "defMultiplier": 10.7597,
+      "goldCost": 44700000,
+      "crystalCost": 12159
+    },
+    {
+      "level": 774,
+      "atkMultiplier": 20.7215,
+      "hpMultiplier": 15.1797,
+      "defMultiplier": 10.7789,
+      "goldCost": 44900000,
+      "crystalCost": 12209
+    },
+    {
+      "level": 775,
+      "atkMultiplier": 20.7625,
+      "hpMultiplier": 15.2083,
+      "defMultiplier": 10.7982,
+      "goldCost": 45100000,
+      "crystalCost": 12259
+    },
+    {
+      "level": 776,
+      "atkMultiplier": 20.8035,
+      "hpMultiplier": 15.237,
+      "defMultiplier": 10.8175,
+      "goldCost": 45300000,
+      "crystalCost": 12309
+    },
+    {
+      "level": 777,
+      "atkMultiplier": 20.8446,
+      "hpMultiplier": 15.2657,
+      "defMultiplier": 10.8368,
+      "goldCost": 45500000,
+      "crystalCost": 12359
+    },
+    {
+      "level": 778,
+      "atkMultiplier": 20.8857,
+      "hpMultiplier": 15.2945,
+      "defMultiplier": 10.8561,
+      "goldCost": 45700000,
+      "crystalCost": 12409
+    },
+    {
+      "level": 779,
+      "atkMultiplier": 20.9268,
+      "hpMultiplier": 15.3232,
+      "defMultiplier": 10.8755,
+      "goldCost": 45900000,
+      "crystalCost": 12459
+    },
+    {
+      "level": 780,
+      "atkMultiplier": 20.968,
+      "hpMultiplier": 15.352,
+      "defMultiplier": 10.8949,
+      "goldCost": 46100000,
+      "crystalCost": 12509
+    },
+    {
+      "level": 781,
+      "atkMultiplier": 21.0092,
+      "hpMultiplier": 15.3808,
+      "defMultiplier": 10.9142,
+      "goldCost": 46300000,
+      "crystalCost": 12559
+    },
+    {
+      "level": 782,
+      "atkMultiplier": 21.0505,
+      "hpMultiplier": 15.4097,
+      "defMultiplier": 10.9336,
+      "goldCost": 46500000,
+      "crystalCost": 12609
+    },
+    {
+      "level": 783,
+      "atkMultiplier": 21.0918,
+      "hpMultiplier": 15.4385,
+      "defMultiplier": 10.953,
+      "goldCost": 46700000,
+      "crystalCost": 12659
+    },
+    {
+      "level": 784,
+      "atkMultiplier": 21.1331,
+      "hpMultiplier": 15.4674,
+      "defMultiplier": 10.9725,
+      "goldCost": 46900000,
+      "crystalCost": 12709
+    },
+    {
+      "level": 785,
+      "atkMultiplier": 21.1745,
+      "hpMultiplier": 15.4963,
+      "defMultiplier": 10.9919,
+      "goldCost": 47100000,
+      "crystalCost": 12759
+    },
+    {
+      "level": 786,
+      "atkMultiplier": 21.2159,
+      "hpMultiplier": 15.5253,
+      "defMultiplier": 11.0114,
+      "goldCost": 47300000,
+      "crystalCost": 12809
+    },
+    {
+      "level": 787,
+      "atkMultiplier": 21.2574,
+      "hpMultiplier": 15.5543,
+      "defMultiplier": 11.0309,
+      "goldCost": 47500000,
+      "crystalCost": 12859
+    },
+    {
+      "level": 788,
+      "atkMultiplier": 21.2989,
+      "hpMultiplier": 15.5833,
+      "defMultiplier": 11.0504,
+      "goldCost": 47700000,
+      "crystalCost": 12909
+    },
+    {
+      "level": 789,
+      "atkMultiplier": 21.3404,
+      "hpMultiplier": 15.6123,
+      "defMultiplier": 11.0699,
+      "goldCost": 47900000,
+      "crystalCost": 12959
+    },
+    {
+      "level": 790,
+      "atkMultiplier": 21.382,
+      "hpMultiplier": 15.6413,
+      "defMultiplier": 11.0894,
+      "goldCost": 48100000,
+      "crystalCost": 13009
+    },
+    {
+      "level": 791,
+      "atkMultiplier": 21.4236,
+      "hpMultiplier": 15.6704,
+      "defMultiplier": 11.109,
+      "goldCost": 48300000,
+      "crystalCost": 13059
+    },
+    {
+      "level": 792,
+      "atkMultiplier": 21.4653,
+      "hpMultiplier": 15.6995,
+      "defMultiplier": 11.1285,
+      "goldCost": 48500000,
+      "crystalCost": 13109
+    },
+    {
+      "level": 793,
+      "atkMultiplier": 21.507,
+      "hpMultiplier": 15.7287,
+      "defMultiplier": 11.1481,
+      "goldCost": 48700000,
+      "crystalCost": 13159
+    },
+    {
+      "level": 794,
+      "atkMultiplier": 21.5487,
+      "hpMultiplier": 15.7578,
+      "defMultiplier": 11.1677,
+      "goldCost": 48900000,
+      "crystalCost": 13209
+    },
+    {
+      "level": 795,
+      "atkMultiplier": 21.5905,
+      "hpMultiplier": 15.787,
+      "defMultiplier": 11.1874,
+      "goldCost": 49100000,
+      "crystalCost": 13259
+    },
+    {
+      "level": 796,
+      "atkMultiplier": 21.6323,
+      "hpMultiplier": 15.8162,
+      "defMultiplier": 11.207,
+      "goldCost": 49300000,
+      "crystalCost": 13309
+    },
+    {
+      "level": 797,
+      "atkMultiplier": 21.6742,
+      "hpMultiplier": 15.8455,
+      "defMultiplier": 11.2266,
+      "goldCost": 49500000,
+      "crystalCost": 13359
+    },
+    {
+      "level": 798,
+      "atkMultiplier": 21.7161,
+      "hpMultiplier": 15.8747,
+      "defMultiplier": 11.2463,
+      "goldCost": 49700000,
+      "crystalCost": 13409
+    },
+    {
+      "level": 799,
+      "atkMultiplier": 21.758,
+      "hpMultiplier": 15.904,
+      "defMultiplier": 11.266,
+      "goldCost": 49900000,
+      "crystalCost": 13459
+    },
+    {
+      "level": 800,
+      "atkMultiplier": 21.8,
+      "hpMultiplier": 15.9333,
+      "defMultiplier": 11.2857,
+      "goldCost": 50100000,
+      "crystalCost": 13509
+    },
+    {
+      "level": 801,
+      "atkMultiplier": 21.842,
+      "hpMultiplier": 15.9627,
+      "defMultiplier": 11.3054,
+      "goldCost": 50300000,
+      "crystalCost": 13559
+    },
+    {
+      "level": 802,
+      "atkMultiplier": 21.8841,
+      "hpMultiplier": 15.9921,
+      "defMultiplier": 11.3252,
+      "goldCost": 50500000,
+      "crystalCost": 13609
+    },
+    {
+      "level": 803,
+      "atkMultiplier": 21.9262,
+      "hpMultiplier": 16.0215,
+      "defMultiplier": 11.3449,
+      "goldCost": 50700000,
+      "crystalCost": 13659
+    },
+    {
+      "level": 804,
+      "atkMultiplier": 21.9683,
+      "hpMultiplier": 16.0509,
+      "defMultiplier": 11.3647,
+      "goldCost": 50900000,
+      "crystalCost": 13709
+    },
+    {
+      "level": 805,
+      "atkMultiplier": 22.0105,
+      "hpMultiplier": 16.0803,
+      "defMultiplier": 11.3845,
+      "goldCost": 51100000,
+      "crystalCost": 13759
+    },
+    {
+      "level": 806,
+      "atkMultiplier": 22.0527,
+      "hpMultiplier": 16.1098,
+      "defMultiplier": 11.4043,
+      "goldCost": 51300000,
+      "crystalCost": 13809
+    },
+    {
+      "level": 807,
+      "atkMultiplier": 22.095,
+      "hpMultiplier": 16.1393,
+      "defMultiplier": 11.4241,
+      "goldCost": 51500000,
+      "crystalCost": 13859
+    },
+    {
+      "level": 808,
+      "atkMultiplier": 22.1373,
+      "hpMultiplier": 16.1689,
+      "defMultiplier": 11.444,
+      "goldCost": 51700000,
+      "crystalCost": 13909
+    },
+    {
+      "level": 809,
+      "atkMultiplier": 22.1796,
+      "hpMultiplier": 16.1984,
+      "defMultiplier": 11.4638,
+      "goldCost": 51900000,
+      "crystalCost": 13959
+    },
+    {
+      "level": 810,
+      "atkMultiplier": 22.222,
+      "hpMultiplier": 16.228,
+      "defMultiplier": 11.4837,
+      "goldCost": 52100000,
+      "crystalCost": 14009
+    },
+    {
+      "level": 811,
+      "atkMultiplier": 22.2644,
+      "hpMultiplier": 16.2576,
+      "defMultiplier": 11.5036,
+      "goldCost": 52300000,
+      "crystalCost": 14059
+    },
+    {
+      "level": 812,
+      "atkMultiplier": 22.3069,
+      "hpMultiplier": 16.2873,
+      "defMultiplier": 11.5235,
+      "goldCost": 52500000,
+      "crystalCost": 14109
+    },
+    {
+      "level": 813,
+      "atkMultiplier": 22.3494,
+      "hpMultiplier": 16.3169,
+      "defMultiplier": 11.5434,
+      "goldCost": 52700000,
+      "crystalCost": 14159
+    },
+    {
+      "level": 814,
+      "atkMultiplier": 22.3919,
+      "hpMultiplier": 16.3466,
+      "defMultiplier": 11.5634,
+      "goldCost": 52900000,
+      "crystalCost": 14209
+    },
+    {
+      "level": 815,
+      "atkMultiplier": 22.4345,
+      "hpMultiplier": 16.3763,
+      "defMultiplier": 11.5834,
+      "goldCost": 53100000,
+      "crystalCost": 14259
+    },
+    {
+      "level": 816,
+      "atkMultiplier": 22.4771,
+      "hpMultiplier": 16.4061,
+      "defMultiplier": 11.6033,
+      "goldCost": 53300000,
+      "crystalCost": 14309
+    },
+    {
+      "level": 817,
+      "atkMultiplier": 22.5198,
+      "hpMultiplier": 16.4359,
+      "defMultiplier": 11.6233,
+      "goldCost": 53500000,
+      "crystalCost": 14359
+    },
+    {
+      "level": 818,
+      "atkMultiplier": 22.5625,
+      "hpMultiplier": 16.4657,
+      "defMultiplier": 11.6433,
+      "goldCost": 53700000,
+      "crystalCost": 14409
+    },
+    {
+      "level": 819,
+      "atkMultiplier": 22.6052,
+      "hpMultiplier": 16.4955,
+      "defMultiplier": 11.6634,
+      "goldCost": 53900000,
+      "crystalCost": 14459
+    },
+    {
+      "level": 820,
+      "atkMultiplier": 22.648,
+      "hpMultiplier": 16.5253,
+      "defMultiplier": 11.6834,
+      "goldCost": 54100000,
+      "crystalCost": 14509
+    },
+    {
+      "level": 821,
+      "atkMultiplier": 22.6908,
+      "hpMultiplier": 16.5552,
+      "defMultiplier": 11.7035,
+      "goldCost": 54300000,
+      "crystalCost": 14559
+    },
+    {
+      "level": 822,
+      "atkMultiplier": 22.7337,
+      "hpMultiplier": 16.5851,
+      "defMultiplier": 11.7236,
+      "goldCost": 54500000,
+      "crystalCost": 14609
+    },
+    {
+      "level": 823,
+      "atkMultiplier": 22.7766,
+      "hpMultiplier": 16.6151,
+      "defMultiplier": 11.7437,
+      "goldCost": 54700000,
+      "crystalCost": 14659
+    },
+    {
+      "level": 824,
+      "atkMultiplier": 22.8195,
+      "hpMultiplier": 16.645,
+      "defMultiplier": 11.7638,
+      "goldCost": 54900000,
+      "crystalCost": 14709
+    },
+    {
+      "level": 825,
+      "atkMultiplier": 22.8625,
+      "hpMultiplier": 16.675,
+      "defMultiplier": 11.7839,
+      "goldCost": 55100000,
+      "crystalCost": 14759
+    },
+    {
+      "level": 826,
+      "atkMultiplier": 22.9055,
+      "hpMultiplier": 16.705,
+      "defMultiplier": 11.8041,
+      "goldCost": 55300000,
+      "crystalCost": 14809
+    },
+    {
+      "level": 827,
+      "atkMultiplier": 22.9486,
+      "hpMultiplier": 16.7351,
+      "defMultiplier": 11.8242,
+      "goldCost": 55500000,
+      "crystalCost": 14859
+    },
+    {
+      "level": 828,
+      "atkMultiplier": 22.9917,
+      "hpMultiplier": 16.7651,
+      "defMultiplier": 11.8444,
+      "goldCost": 55700000,
+      "crystalCost": 14909
+    },
+    {
+      "level": 829,
+      "atkMultiplier": 23.0348,
+      "hpMultiplier": 16.7952,
+      "defMultiplier": 11.8646,
+      "goldCost": 55900000,
+      "crystalCost": 14959
+    },
+    {
+      "level": 830,
+      "atkMultiplier": 23.078,
+      "hpMultiplier": 16.8253,
+      "defMultiplier": 11.8849,
+      "goldCost": 56100000,
+      "crystalCost": 15009
+    },
+    {
+      "level": 831,
+      "atkMultiplier": 23.1212,
+      "hpMultiplier": 16.8555,
+      "defMultiplier": 11.9051,
+      "goldCost": 56300000,
+      "crystalCost": 15059
+    },
+    {
+      "level": 832,
+      "atkMultiplier": 23.1645,
+      "hpMultiplier": 16.8857,
+      "defMultiplier": 11.9253,
+      "goldCost": 56500000,
+      "crystalCost": 15109
+    },
+    {
+      "level": 833,
+      "atkMultiplier": 23.2078,
+      "hpMultiplier": 16.9159,
+      "defMultiplier": 11.9456,
+      "goldCost": 56700000,
+      "crystalCost": 15159
+    },
+    {
+      "level": 834,
+      "atkMultiplier": 23.2511,
+      "hpMultiplier": 16.9461,
+      "defMultiplier": 11.9659,
+      "goldCost": 56900000,
+      "crystalCost": 15209
+    },
+    {
+      "level": 835,
+      "atkMultiplier": 23.2945,
+      "hpMultiplier": 16.9763,
+      "defMultiplier": 11.9862,
+      "goldCost": 57100000,
+      "crystalCost": 15259
+    },
+    {
+      "level": 836,
+      "atkMultiplier": 23.3379,
+      "hpMultiplier": 17.0066,
+      "defMultiplier": 12.0065,
+      "goldCost": 57300000,
+      "crystalCost": 15309
+    },
+    {
+      "level": 837,
+      "atkMultiplier": 23.3814,
+      "hpMultiplier": 17.0369,
+      "defMultiplier": 12.0269,
+      "goldCost": 57500000,
+      "crystalCost": 15359
+    },
+    {
+      "level": 838,
+      "atkMultiplier": 23.4249,
+      "hpMultiplier": 17.0673,
+      "defMultiplier": 12.0472,
+      "goldCost": 57700000,
+      "crystalCost": 15409
+    },
+    {
+      "level": 839,
+      "atkMultiplier": 23.4684,
+      "hpMultiplier": 17.0976,
+      "defMultiplier": 12.0676,
+      "goldCost": 57900000,
+      "crystalCost": 15459
+    },
+    {
+      "level": 840,
+      "atkMultiplier": 23.512,
+      "hpMultiplier": 17.128,
+      "defMultiplier": 12.088,
+      "goldCost": 58100000,
+      "crystalCost": 15509
+    },
+    {
+      "level": 841,
+      "atkMultiplier": 23.5556,
+      "hpMultiplier": 17.1584,
+      "defMultiplier": 12.1084,
+      "goldCost": 58300000,
+      "crystalCost": 15559
+    },
+    {
+      "level": 842,
+      "atkMultiplier": 23.5993,
+      "hpMultiplier": 17.1889,
+      "defMultiplier": 12.1288,
+      "goldCost": 58500000,
+      "crystalCost": 15609
+    },
+    {
+      "level": 843,
+      "atkMultiplier": 23.643,
+      "hpMultiplier": 17.2193,
+      "defMultiplier": 12.1493,
+      "goldCost": 58700000,
+      "crystalCost": 15659
+    },
+    {
+      "level": 844,
+      "atkMultiplier": 23.6867,
+      "hpMultiplier": 17.2498,
+      "defMultiplier": 12.1697,
+      "goldCost": 58900000,
+      "crystalCost": 15709
+    },
+    {
+      "level": 845,
+      "atkMultiplier": 23.7305,
+      "hpMultiplier": 17.2803,
+      "defMultiplier": 12.1902,
+      "goldCost": 59100000,
+      "crystalCost": 15759
+    },
+    {
+      "level": 846,
+      "atkMultiplier": 23.7743,
+      "hpMultiplier": 17.3109,
+      "defMultiplier": 12.2107,
+      "goldCost": 59300000,
+      "crystalCost": 15809
+    },
+    {
+      "level": 847,
+      "atkMultiplier": 23.8182,
+      "hpMultiplier": 17.3415,
+      "defMultiplier": 12.2312,
+      "goldCost": 59500000,
+      "crystalCost": 15859
+    },
+    {
+      "level": 848,
+      "atkMultiplier": 23.8621,
+      "hpMultiplier": 17.3721,
+      "defMultiplier": 12.2517,
+      "goldCost": 59700000,
+      "crystalCost": 15909
+    },
+    {
+      "level": 849,
+      "atkMultiplier": 23.906,
+      "hpMultiplier": 17.4027,
+      "defMultiplier": 12.2723,
+      "goldCost": 59900000,
+      "crystalCost": 15959
+    },
+    {
+      "level": 850,
+      "atkMultiplier": 23.95,
+      "hpMultiplier": 17.4333,
+      "defMultiplier": 12.2929,
+      "goldCost": 60100000,
+      "crystalCost": 16009
+    },
+    {
+      "level": 851,
+      "atkMultiplier": 23.994,
+      "hpMultiplier": 17.464,
+      "defMultiplier": 12.3134,
+      "goldCost": 60300000,
+      "crystalCost": 16059
+    },
+    {
+      "level": 852,
+      "atkMultiplier": 24.0381,
+      "hpMultiplier": 17.4947,
+      "defMultiplier": 12.334,
+      "goldCost": 60500000,
+      "crystalCost": 16109
+    },
+    {
+      "level": 853,
+      "atkMultiplier": 24.0822,
+      "hpMultiplier": 17.5255,
+      "defMultiplier": 12.3546,
+      "goldCost": 60700000,
+      "crystalCost": 16159
+    },
+    {
+      "level": 854,
+      "atkMultiplier": 24.1263,
+      "hpMultiplier": 17.5562,
+      "defMultiplier": 12.3753,
+      "goldCost": 60900000,
+      "crystalCost": 16209
+    },
+    {
+      "level": 855,
+      "atkMultiplier": 24.1705,
+      "hpMultiplier": 17.587,
+      "defMultiplier": 12.3959,
+      "goldCost": 61100000,
+      "crystalCost": 16259
+    },
+    {
+      "level": 856,
+      "atkMultiplier": 24.2147,
+      "hpMultiplier": 17.6178,
+      "defMultiplier": 12.4166,
+      "goldCost": 61300000,
+      "crystalCost": 16309
+    },
+    {
+      "level": 857,
+      "atkMultiplier": 24.259,
+      "hpMultiplier": 17.6487,
+      "defMultiplier": 12.4373,
+      "goldCost": 61500000,
+      "crystalCost": 16359
+    },
+    {
+      "level": 858,
+      "atkMultiplier": 24.3033,
+      "hpMultiplier": 17.6795,
+      "defMultiplier": 12.458,
+      "goldCost": 61700000,
+      "crystalCost": 16409
+    },
+    {
+      "level": 859,
+      "atkMultiplier": 24.3476,
+      "hpMultiplier": 17.7104,
+      "defMultiplier": 12.4787,
+      "goldCost": 61900000,
+      "crystalCost": 16459
+    },
+    {
+      "level": 860,
+      "atkMultiplier": 24.392,
+      "hpMultiplier": 17.7413,
+      "defMultiplier": 12.4994,
+      "goldCost": 62100000,
+      "crystalCost": 16509
+    },
+    {
+      "level": 861,
+      "atkMultiplier": 24.4364,
+      "hpMultiplier": 17.7723,
+      "defMultiplier": 12.5202,
+      "goldCost": 62300000,
+      "crystalCost": 16559
+    },
+    {
+      "level": 862,
+      "atkMultiplier": 24.4809,
+      "hpMultiplier": 17.8033,
+      "defMultiplier": 12.5409,
+      "goldCost": 62500000,
+      "crystalCost": 16609
+    },
+    {
+      "level": 863,
+      "atkMultiplier": 24.5254,
+      "hpMultiplier": 17.8343,
+      "defMultiplier": 12.5617,
+      "goldCost": 62700000,
+      "crystalCost": 16659
+    },
+    {
+      "level": 864,
+      "atkMultiplier": 24.5699,
+      "hpMultiplier": 17.8653,
+      "defMultiplier": 12.5825,
+      "goldCost": 62900000,
+      "crystalCost": 16709
+    },
+    {
+      "level": 865,
+      "atkMultiplier": 24.6145,
+      "hpMultiplier": 17.8963,
+      "defMultiplier": 12.6034,
+      "goldCost": 63100000,
+      "crystalCost": 16759
+    },
+    {
+      "level": 866,
+      "atkMultiplier": 24.6591,
+      "hpMultiplier": 17.9274,
+      "defMultiplier": 12.6242,
+      "goldCost": 63300000,
+      "crystalCost": 16809
+    },
+    {
+      "level": 867,
+      "atkMultiplier": 24.7038,
+      "hpMultiplier": 17.9585,
+      "defMultiplier": 12.645,
+      "goldCost": 63500000,
+      "crystalCost": 16859
+    },
+    {
+      "level": 868,
+      "atkMultiplier": 24.7485,
+      "hpMultiplier": 17.9897,
+      "defMultiplier": 12.6659,
+      "goldCost": 63700000,
+      "crystalCost": 16909
+    },
+    {
+      "level": 869,
+      "atkMultiplier": 24.7932,
+      "hpMultiplier": 18.0208,
+      "defMultiplier": 12.6868,
+      "goldCost": 63900000,
+      "crystalCost": 16959
+    },
+    {
+      "level": 870,
+      "atkMultiplier": 24.838,
+      "hpMultiplier": 18.052,
+      "defMultiplier": 12.7077,
+      "goldCost": 64100000,
+      "crystalCost": 17009
+    },
+    {
+      "level": 871,
+      "atkMultiplier": 24.8828,
+      "hpMultiplier": 18.0832,
+      "defMultiplier": 12.7286,
+      "goldCost": 64300000,
+      "crystalCost": 17059
+    },
+    {
+      "level": 872,
+      "atkMultiplier": 24.9277,
+      "hpMultiplier": 18.1145,
+      "defMultiplier": 12.7496,
+      "goldCost": 64500000,
+      "crystalCost": 17109
+    },
+    {
+      "level": 873,
+      "atkMultiplier": 24.9726,
+      "hpMultiplier": 18.1457,
+      "defMultiplier": 12.7705,
+      "goldCost": 64700000,
+      "crystalCost": 17159
+    },
+    {
+      "level": 874,
+      "atkMultiplier": 25.0175,
+      "hpMultiplier": 18.177,
+      "defMultiplier": 12.7915,
+      "goldCost": 64900000,
+      "crystalCost": 17209
+    },
+    {
+      "level": 875,
+      "atkMultiplier": 25.0625,
+      "hpMultiplier": 18.2083,
+      "defMultiplier": 12.8125,
+      "goldCost": 65100000,
+      "crystalCost": 17259
+    },
+    {
+      "level": 876,
+      "atkMultiplier": 25.1075,
+      "hpMultiplier": 18.2397,
+      "defMultiplier": 12.8335,
+      "goldCost": 65300000,
+      "crystalCost": 17309
+    },
+    {
+      "level": 877,
+      "atkMultiplier": 25.1526,
+      "hpMultiplier": 18.2711,
+      "defMultiplier": 12.8545,
+      "goldCost": 65500000,
+      "crystalCost": 17359
+    },
+    {
+      "level": 878,
+      "atkMultiplier": 25.1977,
+      "hpMultiplier": 18.3025,
+      "defMultiplier": 12.8756,
+      "goldCost": 65700000,
+      "crystalCost": 17409
+    },
+    {
+      "level": 879,
+      "atkMultiplier": 25.2428,
+      "hpMultiplier": 18.3339,
+      "defMultiplier": 12.8966,
+      "goldCost": 65900000,
+      "crystalCost": 17459
+    },
+    {
+      "level": 880,
+      "atkMultiplier": 25.288,
+      "hpMultiplier": 18.3653,
+      "defMultiplier": 12.9177,
+      "goldCost": 66100000,
+      "crystalCost": 17509
+    },
+    {
+      "level": 881,
+      "atkMultiplier": 25.3332,
+      "hpMultiplier": 18.3968,
+      "defMultiplier": 12.9388,
+      "goldCost": 66300000,
+      "crystalCost": 17559
+    },
+    {
+      "level": 882,
+      "atkMultiplier": 25.3785,
+      "hpMultiplier": 18.4283,
+      "defMultiplier": 12.9599,
+      "goldCost": 66500000,
+      "crystalCost": 17609
+    },
+    {
+      "level": 883,
+      "atkMultiplier": 25.4238,
+      "hpMultiplier": 18.4599,
+      "defMultiplier": 12.981,
+      "goldCost": 66700000,
+      "crystalCost": 17659
+    },
+    {
+      "level": 884,
+      "atkMultiplier": 25.4691,
+      "hpMultiplier": 18.4914,
+      "defMultiplier": 13.0022,
+      "goldCost": 66900000,
+      "crystalCost": 17709
+    },
+    {
+      "level": 885,
+      "atkMultiplier": 25.5145,
+      "hpMultiplier": 18.523,
+      "defMultiplier": 13.0234,
+      "goldCost": 67100000,
+      "crystalCost": 17759
+    },
+    {
+      "level": 886,
+      "atkMultiplier": 25.5599,
+      "hpMultiplier": 18.5546,
+      "defMultiplier": 13.0445,
+      "goldCost": 67300000,
+      "crystalCost": 17809
+    },
+    {
+      "level": 887,
+      "atkMultiplier": 25.6054,
+      "hpMultiplier": 18.5863,
+      "defMultiplier": 13.0657,
+      "goldCost": 67500000,
+      "crystalCost": 17859
+    },
+    {
+      "level": 888,
+      "atkMultiplier": 25.6509,
+      "hpMultiplier": 18.6179,
+      "defMultiplier": 13.0869,
+      "goldCost": 67700000,
+      "crystalCost": 17909
+    },
+    {
+      "level": 889,
+      "atkMultiplier": 25.6964,
+      "hpMultiplier": 18.6496,
+      "defMultiplier": 13.1082,
+      "goldCost": 67900000,
+      "crystalCost": 17959
+    },
+    {
+      "level": 890,
+      "atkMultiplier": 25.742,
+      "hpMultiplier": 18.6813,
+      "defMultiplier": 13.1294,
+      "goldCost": 68100000,
+      "crystalCost": 18009
+    },
+    {
+      "level": 891,
+      "atkMultiplier": 25.7876,
+      "hpMultiplier": 18.7131,
+      "defMultiplier": 13.1507,
+      "goldCost": 68300000,
+      "crystalCost": 18059
+    },
+    {
+      "level": 892,
+      "atkMultiplier": 25.8333,
+      "hpMultiplier": 18.7449,
+      "defMultiplier": 13.172,
+      "goldCost": 68500000,
+      "crystalCost": 18109
+    },
+    {
+      "level": 893,
+      "atkMultiplier": 25.879,
+      "hpMultiplier": 18.7767,
+      "defMultiplier": 13.1933,
+      "goldCost": 68700000,
+      "crystalCost": 18159
+    },
+    {
+      "level": 894,
+      "atkMultiplier": 25.9247,
+      "hpMultiplier": 18.8085,
+      "defMultiplier": 13.2146,
+      "goldCost": 68900000,
+      "crystalCost": 18209
+    },
+    {
+      "level": 895,
+      "atkMultiplier": 25.9705,
+      "hpMultiplier": 18.8403,
+      "defMultiplier": 13.2359,
+      "goldCost": 69100000,
+      "crystalCost": 18259
+    },
+    {
+      "level": 896,
+      "atkMultiplier": 26.0163,
+      "hpMultiplier": 18.8722,
+      "defMultiplier": 13.2573,
+      "goldCost": 69300000,
+      "crystalCost": 18309
+    },
+    {
+      "level": 897,
+      "atkMultiplier": 26.0622,
+      "hpMultiplier": 18.9041,
+      "defMultiplier": 13.2786,
+      "goldCost": 69500000,
+      "crystalCost": 18359
+    },
+    {
+      "level": 898,
+      "atkMultiplier": 26.1081,
+      "hpMultiplier": 18.9361,
+      "defMultiplier": 13.3,
+      "goldCost": 69700000,
+      "crystalCost": 18409
+    },
+    {
+      "level": 899,
+      "atkMultiplier": 26.154,
+      "hpMultiplier": 18.968,
+      "defMultiplier": 13.3214,
+      "goldCost": 69900000,
+      "crystalCost": 18459
+    },
+    {
+      "level": 900,
+      "atkMultiplier": 26.2,
+      "hpMultiplier": 19,
+      "defMultiplier": 13.3429,
+      "goldCost": 70100000,
+      "crystalCost": 18509
+    },
+    {
+      "level": 901,
+      "atkMultiplier": 26.246,
+      "hpMultiplier": 19.032,
+      "defMultiplier": 13.3643,
+      "goldCost": 71100000,
+      "crystalCost": 18709
+    },
+    {
+      "level": 902,
+      "atkMultiplier": 26.2921,
+      "hpMultiplier": 19.0641,
+      "defMultiplier": 13.3857,
+      "goldCost": 72100000,
+      "crystalCost": 18909
+    },
+    {
+      "level": 903,
+      "atkMultiplier": 26.3382,
+      "hpMultiplier": 19.0961,
+      "defMultiplier": 13.4072,
+      "goldCost": 73100000,
+      "crystalCost": 19109
+    },
+    {
+      "level": 904,
+      "atkMultiplier": 26.3843,
+      "hpMultiplier": 19.1282,
+      "defMultiplier": 13.4287,
+      "goldCost": 74100000,
+      "crystalCost": 19309
+    },
+    {
+      "level": 905,
+      "atkMultiplier": 26.4305,
+      "hpMultiplier": 19.1603,
+      "defMultiplier": 13.4502,
+      "goldCost": 75100000,
+      "crystalCost": 19509
+    },
+    {
+      "level": 906,
+      "atkMultiplier": 26.4767,
+      "hpMultiplier": 19.1925,
+      "defMultiplier": 13.4717,
+      "goldCost": 76100000,
+      "crystalCost": 19709
+    },
+    {
+      "level": 907,
+      "atkMultiplier": 26.523,
+      "hpMultiplier": 19.2247,
+      "defMultiplier": 13.4933,
+      "goldCost": 77100000,
+      "crystalCost": 19909
+    },
+    {
+      "level": 908,
+      "atkMultiplier": 26.5693,
+      "hpMultiplier": 19.2569,
+      "defMultiplier": 13.5148,
+      "goldCost": 78100000,
+      "crystalCost": 20109
+    },
+    {
+      "level": 909,
+      "atkMultiplier": 26.6156,
+      "hpMultiplier": 19.2891,
+      "defMultiplier": 13.5364,
+      "goldCost": 79100000,
+      "crystalCost": 20309
+    },
+    {
+      "level": 910,
+      "atkMultiplier": 26.662,
+      "hpMultiplier": 19.3213,
+      "defMultiplier": 13.558,
+      "goldCost": 80100000,
+      "crystalCost": 20509
+    },
+    {
+      "level": 911,
+      "atkMultiplier": 26.7084,
+      "hpMultiplier": 19.3536,
+      "defMultiplier": 13.5796,
+      "goldCost": 81100000,
+      "crystalCost": 20709
+    },
+    {
+      "level": 912,
+      "atkMultiplier": 26.7549,
+      "hpMultiplier": 19.3859,
+      "defMultiplier": 13.6012,
+      "goldCost": 82100000,
+      "crystalCost": 20909
+    },
+    {
+      "level": 913,
+      "atkMultiplier": 26.8014,
+      "hpMultiplier": 19.4183,
+      "defMultiplier": 13.6229,
+      "goldCost": 83100000,
+      "crystalCost": 21109
+    },
+    {
+      "level": 914,
+      "atkMultiplier": 26.8479,
+      "hpMultiplier": 19.4506,
+      "defMultiplier": 13.6445,
+      "goldCost": 84100000,
+      "crystalCost": 21309
+    },
+    {
+      "level": 915,
+      "atkMultiplier": 26.8945,
+      "hpMultiplier": 19.483,
+      "defMultiplier": 13.6662,
+      "goldCost": 85100000,
+      "crystalCost": 21509
+    },
+    {
+      "level": 916,
+      "atkMultiplier": 26.9411,
+      "hpMultiplier": 19.5154,
+      "defMultiplier": 13.6879,
+      "goldCost": 86100000,
+      "crystalCost": 21709
+    },
+    {
+      "level": 917,
+      "atkMultiplier": 26.9878,
+      "hpMultiplier": 19.5479,
+      "defMultiplier": 13.7096,
+      "goldCost": 87100000,
+      "crystalCost": 21909
+    },
+    {
+      "level": 918,
+      "atkMultiplier": 27.0345,
+      "hpMultiplier": 19.5803,
+      "defMultiplier": 13.7313,
+      "goldCost": 88100000,
+      "crystalCost": 22109
+    },
+    {
+      "level": 919,
+      "atkMultiplier": 27.0812,
+      "hpMultiplier": 19.6128,
+      "defMultiplier": 13.7531,
+      "goldCost": 89100000,
+      "crystalCost": 22309
+    },
+    {
+      "level": 920,
+      "atkMultiplier": 27.128,
+      "hpMultiplier": 19.6453,
+      "defMultiplier": 13.7749,
+      "goldCost": 90100000,
+      "crystalCost": 22509
+    },
+    {
+      "level": 921,
+      "atkMultiplier": 27.1748,
+      "hpMultiplier": 19.6779,
+      "defMultiplier": 13.7966,
+      "goldCost": 91100000,
+      "crystalCost": 22709
+    },
+    {
+      "level": 922,
+      "atkMultiplier": 27.2217,
+      "hpMultiplier": 19.7105,
+      "defMultiplier": 13.8184,
+      "goldCost": 92100000,
+      "crystalCost": 22909
+    },
+    {
+      "level": 923,
+      "atkMultiplier": 27.2686,
+      "hpMultiplier": 19.7431,
+      "defMultiplier": 13.8402,
+      "goldCost": 93100000,
+      "crystalCost": 23109
+    },
+    {
+      "level": 924,
+      "atkMultiplier": 27.3155,
+      "hpMultiplier": 19.7757,
+      "defMultiplier": 13.8621,
+      "goldCost": 94100000,
+      "crystalCost": 23309
+    },
+    {
+      "level": 925,
+      "atkMultiplier": 27.3625,
+      "hpMultiplier": 19.8083,
+      "defMultiplier": 13.8839,
+      "goldCost": 95100000,
+      "crystalCost": 23509
+    },
+    {
+      "level": 926,
+      "atkMultiplier": 27.4095,
+      "hpMultiplier": 19.841,
+      "defMultiplier": 13.9058,
+      "goldCost": 96100000,
+      "crystalCost": 23709
+    },
+    {
+      "level": 927,
+      "atkMultiplier": 27.4566,
+      "hpMultiplier": 19.8737,
+      "defMultiplier": 13.9277,
+      "goldCost": 97100000,
+      "crystalCost": 23909
+    },
+    {
+      "level": 928,
+      "atkMultiplier": 27.5037,
+      "hpMultiplier": 19.9065,
+      "defMultiplier": 13.9496,
+      "goldCost": 98100000,
+      "crystalCost": 24109
+    },
+    {
+      "level": 929,
+      "atkMultiplier": 27.5508,
+      "hpMultiplier": 19.9392,
+      "defMultiplier": 13.9715,
+      "goldCost": 99100000,
+      "crystalCost": 24309
+    },
+    {
+      "level": 930,
+      "atkMultiplier": 27.598,
+      "hpMultiplier": 19.972,
+      "defMultiplier": 13.9934,
+      "goldCost": 100100000,
+      "crystalCost": 24509
+    },
+    {
+      "level": 931,
+      "atkMultiplier": 27.6452,
+      "hpMultiplier": 20.0048,
+      "defMultiplier": 14.0154,
+      "goldCost": 101100000,
+      "crystalCost": 24709
+    },
+    {
+      "level": 932,
+      "atkMultiplier": 27.6925,
+      "hpMultiplier": 20.0377,
+      "defMultiplier": 14.0373,
+      "goldCost": 102100000,
+      "crystalCost": 24909
+    },
+    {
+      "level": 933,
+      "atkMultiplier": 27.7398,
+      "hpMultiplier": 20.0705,
+      "defMultiplier": 14.0593,
+      "goldCost": 103100000,
+      "crystalCost": 25109
+    },
+    {
+      "level": 934,
+      "atkMultiplier": 27.7871,
+      "hpMultiplier": 20.1034,
+      "defMultiplier": 14.0813,
+      "goldCost": 104100000,
+      "crystalCost": 25309
+    },
+    {
+      "level": 935,
+      "atkMultiplier": 27.8345,
+      "hpMultiplier": 20.1363,
+      "defMultiplier": 14.1034,
+      "goldCost": 105100000,
+      "crystalCost": 25509
+    },
+    {
+      "level": 936,
+      "atkMultiplier": 27.8819,
+      "hpMultiplier": 20.1693,
+      "defMultiplier": 14.1254,
+      "goldCost": 106100000,
+      "crystalCost": 25709
+    },
+    {
+      "level": 937,
+      "atkMultiplier": 27.9294,
+      "hpMultiplier": 20.2023,
+      "defMultiplier": 14.1474,
+      "goldCost": 107100000,
+      "crystalCost": 25909
+    },
+    {
+      "level": 938,
+      "atkMultiplier": 27.9769,
+      "hpMultiplier": 20.2353,
+      "defMultiplier": 14.1695,
+      "goldCost": 108100000,
+      "crystalCost": 26109
+    },
+    {
+      "level": 939,
+      "atkMultiplier": 28.0244,
+      "hpMultiplier": 20.2683,
+      "defMultiplier": 14.1916,
+      "goldCost": 109100000,
+      "crystalCost": 26309
+    },
+    {
+      "level": 940,
+      "atkMultiplier": 28.072,
+      "hpMultiplier": 20.3013,
+      "defMultiplier": 14.2137,
+      "goldCost": 110100000,
+      "crystalCost": 26509
+    },
+    {
+      "level": 941,
+      "atkMultiplier": 28.1196,
+      "hpMultiplier": 20.3344,
+      "defMultiplier": 14.2358,
+      "goldCost": 111100000,
+      "crystalCost": 26709
+    },
+    {
+      "level": 942,
+      "atkMultiplier": 28.1673,
+      "hpMultiplier": 20.3675,
+      "defMultiplier": 14.258,
+      "goldCost": 112100000,
+      "crystalCost": 26909
+    },
+    {
+      "level": 943,
+      "atkMultiplier": 28.215,
+      "hpMultiplier": 20.4007,
+      "defMultiplier": 14.2801,
+      "goldCost": 113100000,
+      "crystalCost": 27109
+    },
+    {
+      "level": 944,
+      "atkMultiplier": 28.2627,
+      "hpMultiplier": 20.4338,
+      "defMultiplier": 14.3023,
+      "goldCost": 114100000,
+      "crystalCost": 27309
+    },
+    {
+      "level": 945,
+      "atkMultiplier": 28.3105,
+      "hpMultiplier": 20.467,
+      "defMultiplier": 14.3245,
+      "goldCost": 115100000,
+      "crystalCost": 27509
+    },
+    {
+      "level": 946,
+      "atkMultiplier": 28.3583,
+      "hpMultiplier": 20.5002,
+      "defMultiplier": 14.3467,
+      "goldCost": 116100000,
+      "crystalCost": 27709
+    },
+    {
+      "level": 947,
+      "atkMultiplier": 28.4062,
+      "hpMultiplier": 20.5335,
+      "defMultiplier": 14.3689,
+      "goldCost": 117100000,
+      "crystalCost": 27909
+    },
+    {
+      "level": 948,
+      "atkMultiplier": 28.4541,
+      "hpMultiplier": 20.5667,
+      "defMultiplier": 14.3912,
+      "goldCost": 118100000,
+      "crystalCost": 28109
+    },
+    {
+      "level": 949,
+      "atkMultiplier": 28.502,
+      "hpMultiplier": 20.6,
+      "defMultiplier": 14.4134,
+      "goldCost": 119100000,
+      "crystalCost": 28309
+    },
+    {
+      "level": 950,
+      "atkMultiplier": 28.55,
+      "hpMultiplier": 20.6333,
+      "defMultiplier": 14.4357,
+      "goldCost": 120100000,
+      "crystalCost": 28509
+    },
+    {
+      "level": 951,
+      "atkMultiplier": 28.598,
+      "hpMultiplier": 20.6667,
+      "defMultiplier": 14.458,
+      "goldCost": 121100000,
+      "crystalCost": 28709
+    },
+    {
+      "level": 952,
+      "atkMultiplier": 28.6461,
+      "hpMultiplier": 20.7001,
+      "defMultiplier": 14.4803,
+      "goldCost": 122100000,
+      "crystalCost": 28909
+    },
+    {
+      "level": 953,
+      "atkMultiplier": 28.6942,
+      "hpMultiplier": 20.7335,
+      "defMultiplier": 14.5026,
+      "goldCost": 123100000,
+      "crystalCost": 29109
+    },
+    {
+      "level": 954,
+      "atkMultiplier": 28.7423,
+      "hpMultiplier": 20.7669,
+      "defMultiplier": 14.525,
+      "goldCost": 124100000,
+      "crystalCost": 29309
+    },
+    {
+      "level": 955,
+      "atkMultiplier": 28.7905,
+      "hpMultiplier": 20.8003,
+      "defMultiplier": 14.5474,
+      "goldCost": 125100000,
+      "crystalCost": 29509
+    },
+    {
+      "level": 956,
+      "atkMultiplier": 28.8387,
+      "hpMultiplier": 20.8338,
+      "defMultiplier": 14.5697,
+      "goldCost": 126100000,
+      "crystalCost": 29709
+    },
+    {
+      "level": 957,
+      "atkMultiplier": 28.887,
+      "hpMultiplier": 20.8673,
+      "defMultiplier": 14.5921,
+      "goldCost": 127100000,
+      "crystalCost": 29909
+    },
+    {
+      "level": 958,
+      "atkMultiplier": 28.9353,
+      "hpMultiplier": 20.9009,
+      "defMultiplier": 14.6145,
+      "goldCost": 128100000,
+      "crystalCost": 30109
+    },
+    {
+      "level": 959,
+      "atkMultiplier": 28.9836,
+      "hpMultiplier": 20.9344,
+      "defMultiplier": 14.637,
+      "goldCost": 129100000,
+      "crystalCost": 30309
+    },
+    {
+      "level": 960,
+      "atkMultiplier": 29.032,
+      "hpMultiplier": 20.968,
+      "defMultiplier": 14.6594,
+      "goldCost": 130100000,
+      "crystalCost": 30509
+    },
+    {
+      "level": 961,
+      "atkMultiplier": 29.0804,
+      "hpMultiplier": 21.0016,
+      "defMultiplier": 14.6819,
+      "goldCost": 131100000,
+      "crystalCost": 30709
+    },
+    {
+      "level": 962,
+      "atkMultiplier": 29.1289,
+      "hpMultiplier": 21.0353,
+      "defMultiplier": 14.7044,
+      "goldCost": 132100000,
+      "crystalCost": 30909
+    },
+    {
+      "level": 963,
+      "atkMultiplier": 29.1774,
+      "hpMultiplier": 21.0689,
+      "defMultiplier": 14.7269,
+      "goldCost": 133100000,
+      "crystalCost": 31109
+    },
+    {
+      "level": 964,
+      "atkMultiplier": 29.2259,
+      "hpMultiplier": 21.1026,
+      "defMultiplier": 14.7494,
+      "goldCost": 134100000,
+      "crystalCost": 31309
+    },
+    {
+      "level": 965,
+      "atkMultiplier": 29.2745,
+      "hpMultiplier": 21.1363,
+      "defMultiplier": 14.7719,
+      "goldCost": 135100000,
+      "crystalCost": 31509
+    },
+    {
+      "level": 966,
+      "atkMultiplier": 29.3231,
+      "hpMultiplier": 21.1701,
+      "defMultiplier": 14.7945,
+      "goldCost": 136100000,
+      "crystalCost": 31709
+    },
+    {
+      "level": 967,
+      "atkMultiplier": 29.3718,
+      "hpMultiplier": 21.2039,
+      "defMultiplier": 14.817,
+      "goldCost": 137100000,
+      "crystalCost": 31909
+    },
+    {
+      "level": 968,
+      "atkMultiplier": 29.4205,
+      "hpMultiplier": 21.2377,
+      "defMultiplier": 14.8396,
+      "goldCost": 138100000,
+      "crystalCost": 32109
+    },
+    {
+      "level": 969,
+      "atkMultiplier": 29.4692,
+      "hpMultiplier": 21.2715,
+      "defMultiplier": 14.8622,
+      "goldCost": 139100000,
+      "crystalCost": 32309
+    },
+    {
+      "level": 970,
+      "atkMultiplier": 29.518,
+      "hpMultiplier": 21.3053,
+      "defMultiplier": 14.8849,
+      "goldCost": 140100000,
+      "crystalCost": 32509
+    },
+    {
+      "level": 971,
+      "atkMultiplier": 29.5668,
+      "hpMultiplier": 21.3392,
+      "defMultiplier": 14.9075,
+      "goldCost": 141100000,
+      "crystalCost": 32709
+    },
+    {
+      "level": 972,
+      "atkMultiplier": 29.6157,
+      "hpMultiplier": 21.3731,
+      "defMultiplier": 14.9301,
+      "goldCost": 142100000,
+      "crystalCost": 32909
+    },
+    {
+      "level": 973,
+      "atkMultiplier": 29.6646,
+      "hpMultiplier": 21.4071,
+      "defMultiplier": 14.9528,
+      "goldCost": 143100000,
+      "crystalCost": 33109
+    },
+    {
+      "level": 974,
+      "atkMultiplier": 29.7135,
+      "hpMultiplier": 21.441,
+      "defMultiplier": 14.9755,
+      "goldCost": 144100000,
+      "crystalCost": 33309
+    },
+    {
+      "level": 975,
+      "atkMultiplier": 29.7625,
+      "hpMultiplier": 21.475,
+      "defMultiplier": 14.9982,
+      "goldCost": 145100000,
+      "crystalCost": 33509
+    },
+    {
+      "level": 976,
+      "atkMultiplier": 29.8115,
+      "hpMultiplier": 21.509,
+      "defMultiplier": 15.0209,
+      "goldCost": 146100000,
+      "crystalCost": 33709
+    },
+    {
+      "level": 977,
+      "atkMultiplier": 29.8606,
+      "hpMultiplier": 21.5431,
+      "defMultiplier": 15.0437,
+      "goldCost": 147100000,
+      "crystalCost": 33909
+    },
+    {
+      "level": 978,
+      "atkMultiplier": 29.9097,
+      "hpMultiplier": 21.5771,
+      "defMultiplier": 15.0664,
+      "goldCost": 148100000,
+      "crystalCost": 34109
+    },
+    {
+      "level": 979,
+      "atkMultiplier": 29.9588,
+      "hpMultiplier": 21.6112,
+      "defMultiplier": 15.0892,
+      "goldCost": 149100000,
+      "crystalCost": 34309
+    },
+    {
+      "level": 980,
+      "atkMultiplier": 30.008,
+      "hpMultiplier": 21.6453,
+      "defMultiplier": 15.112,
+      "goldCost": 150100000,
+      "crystalCost": 34509
+    },
+    {
+      "level": 981,
+      "atkMultiplier": 30.0572,
+      "hpMultiplier": 21.6795,
+      "defMultiplier": 15.1348,
+      "goldCost": 151100000,
+      "crystalCost": 34709
+    },
+    {
+      "level": 982,
+      "atkMultiplier": 30.1065,
+      "hpMultiplier": 21.7137,
+      "defMultiplier": 15.1576,
+      "goldCost": 152100000,
+      "crystalCost": 34909
+    },
+    {
+      "level": 983,
+      "atkMultiplier": 30.1558,
+      "hpMultiplier": 21.7479,
+      "defMultiplier": 15.1805,
+      "goldCost": 153100000,
+      "crystalCost": 35109
+    },
+    {
+      "level": 984,
+      "atkMultiplier": 30.2051,
+      "hpMultiplier": 21.7821,
+      "defMultiplier": 15.2033,
+      "goldCost": 154100000,
+      "crystalCost": 35309
+    },
+    {
+      "level": 985,
+      "atkMultiplier": 30.2545,
+      "hpMultiplier": 21.8163,
+      "defMultiplier": 15.2262,
+      "goldCost": 155100000,
+      "crystalCost": 35509
+    },
+    {
+      "level": 986,
+      "atkMultiplier": 30.3039,
+      "hpMultiplier": 21.8506,
+      "defMultiplier": 15.2491,
+      "goldCost": 156100000,
+      "crystalCost": 35709
+    },
+    {
+      "level": 987,
+      "atkMultiplier": 30.3534,
+      "hpMultiplier": 21.8849,
+      "defMultiplier": 15.272,
+      "goldCost": 157100000,
+      "crystalCost": 35909
+    },
+    {
+      "level": 988,
+      "atkMultiplier": 30.4029,
+      "hpMultiplier": 21.9193,
+      "defMultiplier": 15.2949,
+      "goldCost": 158100000,
+      "crystalCost": 36109
+    },
+    {
+      "level": 989,
+      "atkMultiplier": 30.4524,
+      "hpMultiplier": 21.9536,
+      "defMultiplier": 15.3179,
+      "goldCost": 159100000,
+      "crystalCost": 36309
+    },
+    {
+      "level": 990,
+      "atkMultiplier": 30.502,
+      "hpMultiplier": 21.988,
+      "defMultiplier": 15.3409,
+      "goldCost": 160100000,
+      "crystalCost": 36509
+    },
+    {
+      "level": 991,
+      "atkMultiplier": 30.5516,
+      "hpMultiplier": 22.0224,
+      "defMultiplier": 15.3638,
+      "goldCost": 161100000,
+      "crystalCost": 36709
+    },
+    {
+      "level": 992,
+      "atkMultiplier": 30.6013,
+      "hpMultiplier": 22.0569,
+      "defMultiplier": 15.3868,
+      "goldCost": 162100000,
+      "crystalCost": 36909
+    },
+    {
+      "level": 993,
+      "atkMultiplier": 30.651,
+      "hpMultiplier": 22.0913,
+      "defMultiplier": 15.4098,
+      "goldCost": 163100000,
+      "crystalCost": 37109
+    },
+    {
+      "level": 994,
+      "atkMultiplier": 30.7007,
+      "hpMultiplier": 22.1258,
+      "defMultiplier": 15.4329,
+      "goldCost": 164100000,
+      "crystalCost": 37309
+    },
+    {
+      "level": 995,
+      "atkMultiplier": 30.7505,
+      "hpMultiplier": 22.1603,
+      "defMultiplier": 15.4559,
+      "goldCost": 165100000,
+      "crystalCost": 37509
+    },
+    {
+      "level": 996,
+      "atkMultiplier": 30.8003,
+      "hpMultiplier": 22.1949,
+      "defMultiplier": 15.479,
+      "goldCost": 166100000,
+      "crystalCost": 37709
+    },
+    {
+      "level": 997,
+      "atkMultiplier": 30.8502,
+      "hpMultiplier": 22.2295,
+      "defMultiplier": 15.5021,
+      "goldCost": 167100000,
+      "crystalCost": 37909
+    },
+    {
+      "level": 998,
+      "atkMultiplier": 30.9001,
+      "hpMultiplier": 22.2641,
+      "defMultiplier": 15.5252,
+      "goldCost": 168100000,
+      "crystalCost": 38109
+    },
+    {
+      "level": 999,
+      "atkMultiplier": 30.95,
+      "hpMultiplier": 22.2987,
+      "defMultiplier": 15.5483,
+      "goldCost": 169100000,
+      "crystalCost": 38309
+    },
+    {
+      "level": 1000,
+      "atkMultiplier": 31,
+      "hpMultiplier": 22.3333,
+      "defMultiplier": 15.5714,
+      "goldCost": 170100000,
+      "crystalCost": 38509
+    },
+    {
+      "level": 1001,
+      "atkMultiplier": 31.05,
+      "hpMultiplier": 22.368,
+      "defMultiplier": 15.5946,
+      "goldCost": 171100000,
+      "crystalCost": 38709
+    },
+    {
+      "level": 1002,
+      "atkMultiplier": 31.1001,
+      "hpMultiplier": 22.4027,
+      "defMultiplier": 15.6177,
+      "goldCost": 172100000,
+      "crystalCost": 38909
+    },
+    {
+      "level": 1003,
+      "atkMultiplier": 31.1502,
+      "hpMultiplier": 22.4375,
+      "defMultiplier": 15.6409,
+      "goldCost": 173100000,
+      "crystalCost": 39109
+    },
+    {
+      "level": 1004,
+      "atkMultiplier": 31.2003,
+      "hpMultiplier": 22.4722,
+      "defMultiplier": 15.6641,
+      "goldCost": 174100000,
+      "crystalCost": 39309
+    },
+    {
+      "level": 1005,
+      "atkMultiplier": 31.2505,
+      "hpMultiplier": 22.507,
+      "defMultiplier": 15.6874,
+      "goldCost": 175100000,
+      "crystalCost": 39509
+    },
+    {
+      "level": 1006,
+      "atkMultiplier": 31.3007,
+      "hpMultiplier": 22.5418,
+      "defMultiplier": 15.7106,
+      "goldCost": 176100000,
+      "crystalCost": 39709
+    },
+    {
+      "level": 1007,
+      "atkMultiplier": 31.351,
+      "hpMultiplier": 22.5767,
+      "defMultiplier": 15.7338,
+      "goldCost": 177100000,
+      "crystalCost": 39909
+    },
+    {
+      "level": 1008,
+      "atkMultiplier": 31.4013,
+      "hpMultiplier": 22.6115,
+      "defMultiplier": 15.7571,
+      "goldCost": 178100000,
+      "crystalCost": 40109
+    },
+    {
+      "level": 1009,
+      "atkMultiplier": 31.4516,
+      "hpMultiplier": 22.6464,
+      "defMultiplier": 15.7804,
+      "goldCost": 179100000,
+      "crystalCost": 40309
+    },
+    {
+      "level": 1010,
+      "atkMultiplier": 31.502,
+      "hpMultiplier": 22.6813,
+      "defMultiplier": 15.8037,
+      "goldCost": 180100000,
+      "crystalCost": 40509
+    },
+    {
+      "level": 1011,
+      "atkMultiplier": 31.5524,
+      "hpMultiplier": 22.7163,
+      "defMultiplier": 15.827,
+      "goldCost": 181100000,
+      "crystalCost": 40709
+    },
+    {
+      "level": 1012,
+      "atkMultiplier": 31.6029,
+      "hpMultiplier": 22.7513,
+      "defMultiplier": 15.8504,
+      "goldCost": 182100000,
+      "crystalCost": 40909
+    },
+    {
+      "level": 1013,
+      "atkMultiplier": 31.6534,
+      "hpMultiplier": 22.7863,
+      "defMultiplier": 15.8737,
+      "goldCost": 183100000,
+      "crystalCost": 41109
+    },
+    {
+      "level": 1014,
+      "atkMultiplier": 31.7039,
+      "hpMultiplier": 22.8213,
+      "defMultiplier": 15.8971,
+      "goldCost": 184100000,
+      "crystalCost": 41309
+    },
+    {
+      "level": 1015,
+      "atkMultiplier": 31.7545,
+      "hpMultiplier": 22.8563,
+      "defMultiplier": 15.9205,
+      "goldCost": 185100000,
+      "crystalCost": 41509
+    },
+    {
+      "level": 1016,
+      "atkMultiplier": 31.8051,
+      "hpMultiplier": 22.8914,
+      "defMultiplier": 15.9439,
+      "goldCost": 186100000,
+      "crystalCost": 41709
+    },
+    {
+      "level": 1017,
+      "atkMultiplier": 31.8558,
+      "hpMultiplier": 22.9265,
+      "defMultiplier": 15.9673,
+      "goldCost": 187100000,
+      "crystalCost": 41909
+    },
+    {
+      "level": 1018,
+      "atkMultiplier": 31.9065,
+      "hpMultiplier": 22.9617,
+      "defMultiplier": 15.9908,
+      "goldCost": 188100000,
+      "crystalCost": 42109
+    },
+    {
+      "level": 1019,
+      "atkMultiplier": 31.9572,
+      "hpMultiplier": 22.9968,
+      "defMultiplier": 16.0142,
+      "goldCost": 189100000,
+      "crystalCost": 42309
+    },
+    {
+      "level": 1020,
+      "atkMultiplier": 32.008,
+      "hpMultiplier": 23.032,
+      "defMultiplier": 16.0377,
+      "goldCost": 190100000,
+      "crystalCost": 42509
+    },
+    {
+      "level": 1021,
+      "atkMultiplier": 32.0588,
+      "hpMultiplier": 23.0672,
+      "defMultiplier": 16.0612,
+      "goldCost": 191100000,
+      "crystalCost": 42709
+    },
+    {
+      "level": 1022,
+      "atkMultiplier": 32.1097,
+      "hpMultiplier": 23.1025,
+      "defMultiplier": 16.0847,
+      "goldCost": 192100000,
+      "crystalCost": 42909
+    },
+    {
+      "level": 1023,
+      "atkMultiplier": 32.1606,
+      "hpMultiplier": 23.1377,
+      "defMultiplier": 16.1082,
+      "goldCost": 193100000,
+      "crystalCost": 43109
+    },
+    {
+      "level": 1024,
+      "atkMultiplier": 32.2115,
+      "hpMultiplier": 23.173,
+      "defMultiplier": 16.1318,
+      "goldCost": 194100000,
+      "crystalCost": 43309
+    },
+    {
+      "level": 1025,
+      "atkMultiplier": 32.2625,
+      "hpMultiplier": 23.2083,
+      "defMultiplier": 16.1554,
+      "goldCost": 195100000,
+      "crystalCost": 43509
+    },
+    {
+      "level": 1026,
+      "atkMultiplier": 32.3135,
+      "hpMultiplier": 23.2437,
+      "defMultiplier": 16.1789,
+      "goldCost": 196100000,
+      "crystalCost": 43709
+    },
+    {
+      "level": 1027,
+      "atkMultiplier": 32.3646,
+      "hpMultiplier": 23.2791,
+      "defMultiplier": 16.2025,
+      "goldCost": 197100000,
+      "crystalCost": 43909
+    },
+    {
+      "level": 1028,
+      "atkMultiplier": 32.4157,
+      "hpMultiplier": 23.3145,
+      "defMultiplier": 16.2261,
+      "goldCost": 198100000,
+      "crystalCost": 44109
+    },
+    {
+      "level": 1029,
+      "atkMultiplier": 32.4668,
+      "hpMultiplier": 23.3499,
+      "defMultiplier": 16.2498,
+      "goldCost": 199100000,
+      "crystalCost": 44309
+    },
+    {
+      "level": 1030,
+      "atkMultiplier": 32.518,
+      "hpMultiplier": 23.3853,
+      "defMultiplier": 16.2734,
+      "goldCost": 200100000,
+      "crystalCost": 44509
+    },
+    {
+      "level": 1031,
+      "atkMultiplier": 32.5692,
+      "hpMultiplier": 23.4208,
+      "defMultiplier": 16.2971,
+      "goldCost": 201100000,
+      "crystalCost": 44709
+    },
+    {
+      "level": 1032,
+      "atkMultiplier": 32.6205,
+      "hpMultiplier": 23.4563,
+      "defMultiplier": 16.3208,
+      "goldCost": 202100000,
+      "crystalCost": 44909
+    },
+    {
+      "level": 1033,
+      "atkMultiplier": 32.6718,
+      "hpMultiplier": 23.4919,
+      "defMultiplier": 16.3445,
+      "goldCost": 203100000,
+      "crystalCost": 45109
+    },
+    {
+      "level": 1034,
+      "atkMultiplier": 32.7231,
+      "hpMultiplier": 23.5274,
+      "defMultiplier": 16.3682,
+      "goldCost": 204100000,
+      "crystalCost": 45309
+    },
+    {
+      "level": 1035,
+      "atkMultiplier": 32.7745,
+      "hpMultiplier": 23.563,
+      "defMultiplier": 16.3919,
+      "goldCost": 205100000,
+      "crystalCost": 45509
+    },
+    {
+      "level": 1036,
+      "atkMultiplier": 32.8259,
+      "hpMultiplier": 23.5986,
+      "defMultiplier": 16.4157,
+      "goldCost": 206100000,
+      "crystalCost": 45709
+    },
+    {
+      "level": 1037,
+      "atkMultiplier": 32.8774,
+      "hpMultiplier": 23.6343,
+      "defMultiplier": 16.4394,
+      "goldCost": 207100000,
+      "crystalCost": 45909
+    },
+    {
+      "level": 1038,
+      "atkMultiplier": 32.9289,
+      "hpMultiplier": 23.6699,
+      "defMultiplier": 16.4632,
+      "goldCost": 208100000,
+      "crystalCost": 46109
+    },
+    {
+      "level": 1039,
+      "atkMultiplier": 32.9804,
+      "hpMultiplier": 23.7056,
+      "defMultiplier": 16.487,
+      "goldCost": 209100000,
+      "crystalCost": 46309
+    },
+    {
+      "level": 1040,
+      "atkMultiplier": 33.032,
+      "hpMultiplier": 23.7413,
+      "defMultiplier": 16.5109,
+      "goldCost": 210100000,
+      "crystalCost": 46509
+    },
+    {
+      "level": 1041,
+      "atkMultiplier": 33.0836,
+      "hpMultiplier": 23.7771,
+      "defMultiplier": 16.5347,
+      "goldCost": 211100000,
+      "crystalCost": 46709
+    },
+    {
+      "level": 1042,
+      "atkMultiplier": 33.1353,
+      "hpMultiplier": 23.8129,
+      "defMultiplier": 16.5585,
+      "goldCost": 212100000,
+      "crystalCost": 46909
+    },
+    {
+      "level": 1043,
+      "atkMultiplier": 33.187,
+      "hpMultiplier": 23.8487,
+      "defMultiplier": 16.5824,
+      "goldCost": 213100000,
+      "crystalCost": 47109
+    },
+    {
+      "level": 1044,
+      "atkMultiplier": 33.2387,
+      "hpMultiplier": 23.8845,
+      "defMultiplier": 16.6063,
+      "goldCost": 214100000,
+      "crystalCost": 47309
+    },
+    {
+      "level": 1045,
+      "atkMultiplier": 33.2905,
+      "hpMultiplier": 23.9203,
+      "defMultiplier": 16.6302,
+      "goldCost": 215100000,
+      "crystalCost": 47509
+    },
+    {
+      "level": 1046,
+      "atkMultiplier": 33.3423,
+      "hpMultiplier": 23.9562,
+      "defMultiplier": 16.6541,
+      "goldCost": 216100000,
+      "crystalCost": 47709
+    },
+    {
+      "level": 1047,
+      "atkMultiplier": 33.3942,
+      "hpMultiplier": 23.9921,
+      "defMultiplier": 16.6781,
+      "goldCost": 217100000,
+      "crystalCost": 47909
+    },
+    {
+      "level": 1048,
+      "atkMultiplier": 33.4461,
+      "hpMultiplier": 24.0281,
+      "defMultiplier": 16.702,
+      "goldCost": 218100000,
+      "crystalCost": 48109
+    },
+    {
+      "level": 1049,
+      "atkMultiplier": 33.498,
+      "hpMultiplier": 24.064,
+      "defMultiplier": 16.726,
+      "goldCost": 219100000,
+      "crystalCost": 48309
+    },
+    {
+      "level": 1050,
+      "atkMultiplier": 33.55,
+      "hpMultiplier": 24.1,
+      "defMultiplier": 16.75,
+      "goldCost": 220100000,
+      "crystalCost": 48509
+    },
+    {
+      "level": 1051,
+      "atkMultiplier": 33.602,
+      "hpMultiplier": 24.136,
+      "defMultiplier": 16.774,
+      "goldCost": 221100000,
+      "crystalCost": 48709
+    },
+    {
+      "level": 1052,
+      "atkMultiplier": 33.6541,
+      "hpMultiplier": 24.1721,
+      "defMultiplier": 16.798,
+      "goldCost": 222100000,
+      "crystalCost": 48909
+    },
+    {
+      "level": 1053,
+      "atkMultiplier": 33.7062,
+      "hpMultiplier": 24.2081,
+      "defMultiplier": 16.8221,
+      "goldCost": 223100000,
+      "crystalCost": 49109
+    },
+    {
+      "level": 1054,
+      "atkMultiplier": 33.7583,
+      "hpMultiplier": 24.2442,
+      "defMultiplier": 16.8461,
+      "goldCost": 224100000,
+      "crystalCost": 49309
+    },
+    {
+      "level": 1055,
+      "atkMultiplier": 33.8105,
+      "hpMultiplier": 24.2803,
+      "defMultiplier": 16.8702,
+      "goldCost": 225100000,
+      "crystalCost": 49509
+    },
+    {
+      "level": 1056,
+      "atkMultiplier": 33.8627,
+      "hpMultiplier": 24.3165,
+      "defMultiplier": 16.8943,
+      "goldCost": 226100000,
+      "crystalCost": 49709
+    },
+    {
+      "level": 1057,
+      "atkMultiplier": 33.915,
+      "hpMultiplier": 24.3527,
+      "defMultiplier": 16.9184,
+      "goldCost": 227100000,
+      "crystalCost": 49909
+    },
+    {
+      "level": 1058,
+      "atkMultiplier": 33.9673,
+      "hpMultiplier": 24.3889,
+      "defMultiplier": 16.9425,
+      "goldCost": 228100000,
+      "crystalCost": 50109
+    },
+    {
+      "level": 1059,
+      "atkMultiplier": 34.0196,
+      "hpMultiplier": 24.4251,
+      "defMultiplier": 16.9667,
+      "goldCost": 229100000,
+      "crystalCost": 50309
+    },
+    {
+      "level": 1060,
+      "atkMultiplier": 34.072,
+      "hpMultiplier": 24.4613,
+      "defMultiplier": 16.9909,
+      "goldCost": 230100000,
+      "crystalCost": 50509
+    },
+    {
+      "level": 1061,
+      "atkMultiplier": 34.1244,
+      "hpMultiplier": 24.4976,
+      "defMultiplier": 17.015,
+      "goldCost": 231100000,
+      "crystalCost": 50709
+    },
+    {
+      "level": 1062,
+      "atkMultiplier": 34.1769,
+      "hpMultiplier": 24.5339,
+      "defMultiplier": 17.0392,
+      "goldCost": 232100000,
+      "crystalCost": 50909
+    },
+    {
+      "level": 1063,
+      "atkMultiplier": 34.2294,
+      "hpMultiplier": 24.5703,
+      "defMultiplier": 17.0634,
+      "goldCost": 233100000,
+      "crystalCost": 51109
+    },
+    {
+      "level": 1064,
+      "atkMultiplier": 34.2819,
+      "hpMultiplier": 24.6066,
+      "defMultiplier": 17.0877,
+      "goldCost": 234100000,
+      "crystalCost": 51309
+    },
+    {
+      "level": 1065,
+      "atkMultiplier": 34.3345,
+      "hpMultiplier": 24.643,
+      "defMultiplier": 17.1119,
+      "goldCost": 235100000,
+      "crystalCost": 51509
+    },
+    {
+      "level": 1066,
+      "atkMultiplier": 34.3871,
+      "hpMultiplier": 24.6794,
+      "defMultiplier": 17.1362,
+      "goldCost": 236100000,
+      "crystalCost": 51709
+    },
+    {
+      "level": 1067,
+      "atkMultiplier": 34.4398,
+      "hpMultiplier": 24.7159,
+      "defMultiplier": 17.1605,
+      "goldCost": 237100000,
+      "crystalCost": 51909
+    },
+    {
+      "level": 1068,
+      "atkMultiplier": 34.4925,
+      "hpMultiplier": 24.7523,
+      "defMultiplier": 17.1848,
+      "goldCost": 238100000,
+      "crystalCost": 52109
+    },
+    {
+      "level": 1069,
+      "atkMultiplier": 34.5452,
+      "hpMultiplier": 24.7888,
+      "defMultiplier": 17.2091,
+      "goldCost": 239100000,
+      "crystalCost": 52309
+    },
+    {
+      "level": 1070,
+      "atkMultiplier": 34.598,
+      "hpMultiplier": 24.8253,
+      "defMultiplier": 17.2334,
+      "goldCost": 240100000,
+      "crystalCost": 52509
+    },
+    {
+      "level": 1071,
+      "atkMultiplier": 34.6508,
+      "hpMultiplier": 24.8619,
+      "defMultiplier": 17.2578,
+      "goldCost": 241100000,
+      "crystalCost": 52709
+    },
+    {
+      "level": 1072,
+      "atkMultiplier": 34.7037,
+      "hpMultiplier": 24.8985,
+      "defMultiplier": 17.2821,
+      "goldCost": 242100000,
+      "crystalCost": 52909
+    },
+    {
+      "level": 1073,
+      "atkMultiplier": 34.7566,
+      "hpMultiplier": 24.9351,
+      "defMultiplier": 17.3065,
+      "goldCost": 243100000,
+      "crystalCost": 53109
+    },
+    {
+      "level": 1074,
+      "atkMultiplier": 34.8095,
+      "hpMultiplier": 24.9717,
+      "defMultiplier": 17.3309,
+      "goldCost": 244100000,
+      "crystalCost": 53309
+    },
+    {
+      "level": 1075,
+      "atkMultiplier": 34.8625,
+      "hpMultiplier": 25.0083,
+      "defMultiplier": 17.3554,
+      "goldCost": 245100000,
+      "crystalCost": 53509
+    },
+    {
+      "level": 1076,
+      "atkMultiplier": 34.9155,
+      "hpMultiplier": 25.045,
+      "defMultiplier": 17.3798,
+      "goldCost": 246100000,
+      "crystalCost": 53709
+    },
+    {
+      "level": 1077,
+      "atkMultiplier": 34.9686,
+      "hpMultiplier": 25.0817,
+      "defMultiplier": 17.4042,
+      "goldCost": 247100000,
+      "crystalCost": 53909
+    },
+    {
+      "level": 1078,
+      "atkMultiplier": 35.0217,
+      "hpMultiplier": 25.1185,
+      "defMultiplier": 17.4287,
+      "goldCost": 248100000,
+      "crystalCost": 54109
+    },
+    {
+      "level": 1079,
+      "atkMultiplier": 35.0748,
+      "hpMultiplier": 25.1552,
+      "defMultiplier": 17.4532,
+      "goldCost": 249100000,
+      "crystalCost": 54309
+    },
+    {
+      "level": 1080,
+      "atkMultiplier": 35.128,
+      "hpMultiplier": 25.192,
+      "defMultiplier": 17.4777,
+      "goldCost": 250100000,
+      "crystalCost": 54509
+    },
+    {
+      "level": 1081,
+      "atkMultiplier": 35.1812,
+      "hpMultiplier": 25.2288,
+      "defMultiplier": 17.5022,
+      "goldCost": 251100000,
+      "crystalCost": 54709
+    },
+    {
+      "level": 1082,
+      "atkMultiplier": 35.2345,
+      "hpMultiplier": 25.2657,
+      "defMultiplier": 17.5268,
+      "goldCost": 252100000,
+      "crystalCost": 54909
+    },
+    {
+      "level": 1083,
+      "atkMultiplier": 35.2878,
+      "hpMultiplier": 25.3025,
+      "defMultiplier": 17.5513,
+      "goldCost": 253100000,
+      "crystalCost": 55109
+    },
+    {
+      "level": 1084,
+      "atkMultiplier": 35.3411,
+      "hpMultiplier": 25.3394,
+      "defMultiplier": 17.5759,
+      "goldCost": 254100000,
+      "crystalCost": 55309
+    },
+    {
+      "level": 1085,
+      "atkMultiplier": 35.3945,
+      "hpMultiplier": 25.3763,
+      "defMultiplier": 17.6005,
+      "goldCost": 255100000,
+      "crystalCost": 55509
+    },
+    {
+      "level": 1086,
+      "atkMultiplier": 35.4479,
+      "hpMultiplier": 25.4133,
+      "defMultiplier": 17.6251,
+      "goldCost": 256100000,
+      "crystalCost": 55709
+    },
+    {
+      "level": 1087,
+      "atkMultiplier": 35.5014,
+      "hpMultiplier": 25.4503,
+      "defMultiplier": 17.6497,
+      "goldCost": 257100000,
+      "crystalCost": 55909
+    },
+    {
+      "level": 1088,
+      "atkMultiplier": 35.5549,
+      "hpMultiplier": 25.4873,
+      "defMultiplier": 17.6744,
+      "goldCost": 258100000,
+      "crystalCost": 56109
+    },
+    {
+      "level": 1089,
+      "atkMultiplier": 35.6084,
+      "hpMultiplier": 25.5243,
+      "defMultiplier": 17.699,
+      "goldCost": 259100000,
+      "crystalCost": 56309
+    },
+    {
+      "level": 1090,
+      "atkMultiplier": 35.662,
+      "hpMultiplier": 25.5613,
+      "defMultiplier": 17.7237,
+      "goldCost": 260100000,
+      "crystalCost": 56509
+    },
+    {
+      "level": 1091,
+      "atkMultiplier": 35.7156,
+      "hpMultiplier": 25.5984,
+      "defMultiplier": 17.7484,
+      "goldCost": 261100000,
+      "crystalCost": 56709
+    },
+    {
+      "level": 1092,
+      "atkMultiplier": 35.7693,
+      "hpMultiplier": 25.6355,
+      "defMultiplier": 17.7731,
+      "goldCost": 262100000,
+      "crystalCost": 56909
+    },
+    {
+      "level": 1093,
+      "atkMultiplier": 35.823,
+      "hpMultiplier": 25.6727,
+      "defMultiplier": 17.7978,
+      "goldCost": 263100000,
+      "crystalCost": 57109
+    },
+    {
+      "level": 1094,
+      "atkMultiplier": 35.8767,
+      "hpMultiplier": 25.7098,
+      "defMultiplier": 17.8226,
+      "goldCost": 264100000,
+      "crystalCost": 57309
+    },
+    {
+      "level": 1095,
+      "atkMultiplier": 35.9305,
+      "hpMultiplier": 25.747,
+      "defMultiplier": 17.8474,
+      "goldCost": 265100000,
+      "crystalCost": 57509
+    },
+    {
+      "level": 1096,
+      "atkMultiplier": 35.9843,
+      "hpMultiplier": 25.7842,
+      "defMultiplier": 17.8721,
+      "goldCost": 266100000,
+      "crystalCost": 57709
+    },
+    {
+      "level": 1097,
+      "atkMultiplier": 36.0382,
+      "hpMultiplier": 25.8215,
+      "defMultiplier": 17.8969,
+      "goldCost": 267100000,
+      "crystalCost": 57909
+    },
+    {
+      "level": 1098,
+      "atkMultiplier": 36.0921,
+      "hpMultiplier": 25.8587,
+      "defMultiplier": 17.9217,
+      "goldCost": 268100000,
+      "crystalCost": 58109
+    },
+    {
+      "level": 1099,
+      "atkMultiplier": 36.146,
+      "hpMultiplier": 25.896,
+      "defMultiplier": 17.9466,
+      "goldCost": 269100000,
+      "crystalCost": 58309
+    },
+    {
+      "level": 1100,
+      "atkMultiplier": 36.2,
+      "hpMultiplier": 25.9333,
+      "defMultiplier": 17.9714,
+      "goldCost": 270100000,
+      "crystalCost": 58509
+    },
+    {
+      "level": 1101,
+      "atkMultiplier": 36.254,
+      "hpMultiplier": 25.9707,
+      "defMultiplier": 17.9963,
+      "goldCost": 271100000,
+      "crystalCost": 58709
+    },
+    {
+      "level": 1102,
+      "atkMultiplier": 36.3081,
+      "hpMultiplier": 26.0081,
+      "defMultiplier": 18.0212,
+      "goldCost": 272100000,
+      "crystalCost": 58909
+    },
+    {
+      "level": 1103,
+      "atkMultiplier": 36.3622,
+      "hpMultiplier": 26.0455,
+      "defMultiplier": 18.0461,
+      "goldCost": 273100000,
+      "crystalCost": 59109
+    },
+    {
+      "level": 1104,
+      "atkMultiplier": 36.4163,
+      "hpMultiplier": 26.0829,
+      "defMultiplier": 18.071,
+      "goldCost": 274100000,
+      "crystalCost": 59309
+    },
+    {
+      "level": 1105,
+      "atkMultiplier": 36.4705,
+      "hpMultiplier": 26.1203,
+      "defMultiplier": 18.0959,
+      "goldCost": 275100000,
+      "crystalCost": 59509
+    },
+    {
+      "level": 1106,
+      "atkMultiplier": 36.5247,
+      "hpMultiplier": 26.1578,
+      "defMultiplier": 18.1209,
+      "goldCost": 276100000,
+      "crystalCost": 59709
+    },
+    {
+      "level": 1107,
+      "atkMultiplier": 36.579,
+      "hpMultiplier": 26.1953,
+      "defMultiplier": 18.1458,
+      "goldCost": 277100000,
+      "crystalCost": 59909
+    },
+    {
+      "level": 1108,
+      "atkMultiplier": 36.6333,
+      "hpMultiplier": 26.2329,
+      "defMultiplier": 18.1708,
+      "goldCost": 278100000,
+      "crystalCost": 60109
+    },
+    {
+      "level": 1109,
+      "atkMultiplier": 36.6876,
+      "hpMultiplier": 26.2704,
+      "defMultiplier": 18.1958,
+      "goldCost": 279100000,
+      "crystalCost": 60309
+    },
+    {
+      "level": 1110,
+      "atkMultiplier": 36.742,
+      "hpMultiplier": 26.308,
+      "defMultiplier": 18.2209,
+      "goldCost": 280100000,
+      "crystalCost": 60509
+    },
+    {
+      "level": 1111,
+      "atkMultiplier": 36.7964,
+      "hpMultiplier": 26.3456,
+      "defMultiplier": 18.2459,
+      "goldCost": 281100000,
+      "crystalCost": 60709
+    },
+    {
+      "level": 1112,
+      "atkMultiplier": 36.8509,
+      "hpMultiplier": 26.3833,
+      "defMultiplier": 18.2709,
+      "goldCost": 282100000,
+      "crystalCost": 60909
+    },
+    {
+      "level": 1113,
+      "atkMultiplier": 36.9054,
+      "hpMultiplier": 26.4209,
+      "defMultiplier": 18.296,
+      "goldCost": 283100000,
+      "crystalCost": 61109
+    },
+    {
+      "level": 1114,
+      "atkMultiplier": 36.9599,
+      "hpMultiplier": 26.4586,
+      "defMultiplier": 18.3211,
+      "goldCost": 284100000,
+      "crystalCost": 61309
+    },
+    {
+      "level": 1115,
+      "atkMultiplier": 37.0145,
+      "hpMultiplier": 26.4963,
+      "defMultiplier": 18.3462,
+      "goldCost": 285100000,
+      "crystalCost": 61509
+    },
+    {
+      "level": 1116,
+      "atkMultiplier": 37.0691,
+      "hpMultiplier": 26.5341,
+      "defMultiplier": 18.3713,
+      "goldCost": 286100000,
+      "crystalCost": 61709
+    },
+    {
+      "level": 1117,
+      "atkMultiplier": 37.1238,
+      "hpMultiplier": 26.5719,
+      "defMultiplier": 18.3965,
+      "goldCost": 287100000,
+      "crystalCost": 61909
+    },
+    {
+      "level": 1118,
+      "atkMultiplier": 37.1785,
+      "hpMultiplier": 26.6097,
+      "defMultiplier": 18.4216,
+      "goldCost": 288100000,
+      "crystalCost": 62109
+    },
+    {
+      "level": 1119,
+      "atkMultiplier": 37.2332,
+      "hpMultiplier": 26.6475,
+      "defMultiplier": 18.4468,
+      "goldCost": 289100000,
+      "crystalCost": 62309
+    },
+    {
+      "level": 1120,
+      "atkMultiplier": 37.288,
+      "hpMultiplier": 26.6853,
+      "defMultiplier": 18.472,
+      "goldCost": 290100000,
+      "crystalCost": 62509
+    },
+    {
+      "level": 1121,
+      "atkMultiplier": 37.3428,
+      "hpMultiplier": 26.7232,
+      "defMultiplier": 18.4972,
+      "goldCost": 291100000,
+      "crystalCost": 62709
+    },
+    {
+      "level": 1122,
+      "atkMultiplier": 37.3977,
+      "hpMultiplier": 26.7611,
+      "defMultiplier": 18.5224,
+      "goldCost": 292100000,
+      "crystalCost": 62909
+    },
+    {
+      "level": 1123,
+      "atkMultiplier": 37.4526,
+      "hpMultiplier": 26.7991,
+      "defMultiplier": 18.5477,
+      "goldCost": 293100000,
+      "crystalCost": 63109
+    },
+    {
+      "level": 1124,
+      "atkMultiplier": 37.5075,
+      "hpMultiplier": 26.837,
+      "defMultiplier": 18.5729,
+      "goldCost": 294100000,
+      "crystalCost": 63309
+    },
+    {
+      "level": 1125,
+      "atkMultiplier": 37.5625,
+      "hpMultiplier": 26.875,
+      "defMultiplier": 18.5982,
+      "goldCost": 295100000,
+      "crystalCost": 63509
+    },
+    {
+      "level": 1126,
+      "atkMultiplier": 37.6175,
+      "hpMultiplier": 26.913,
+      "defMultiplier": 18.6235,
+      "goldCost": 296100000,
+      "crystalCost": 63709
+    },
+    {
+      "level": 1127,
+      "atkMultiplier": 37.6726,
+      "hpMultiplier": 26.9511,
+      "defMultiplier": 18.6488,
+      "goldCost": 297100000,
+      "crystalCost": 63909
+    },
+    {
+      "level": 1128,
+      "atkMultiplier": 37.7277,
+      "hpMultiplier": 26.9891,
+      "defMultiplier": 18.6741,
+      "goldCost": 298100000,
+      "crystalCost": 64109
+    },
+    {
+      "level": 1129,
+      "atkMultiplier": 37.7828,
+      "hpMultiplier": 27.0272,
+      "defMultiplier": 18.6995,
+      "goldCost": 299100000,
+      "crystalCost": 64309
+    },
+    {
+      "level": 1130,
+      "atkMultiplier": 37.838,
+      "hpMultiplier": 27.0653,
+      "defMultiplier": 18.7249,
+      "goldCost": 300100000,
+      "crystalCost": 64509
+    },
+    {
+      "level": 1131,
+      "atkMultiplier": 37.8932,
+      "hpMultiplier": 27.1035,
+      "defMultiplier": 18.7502,
+      "goldCost": 301100000,
+      "crystalCost": 64709
+    },
+    {
+      "level": 1132,
+      "atkMultiplier": 37.9485,
+      "hpMultiplier": 27.1417,
+      "defMultiplier": 18.7756,
+      "goldCost": 302100000,
+      "crystalCost": 64909
+    },
+    {
+      "level": 1133,
+      "atkMultiplier": 38.0038,
+      "hpMultiplier": 27.1799,
+      "defMultiplier": 18.801,
+      "goldCost": 303100000,
+      "crystalCost": 65109
+    },
+    {
+      "level": 1134,
+      "atkMultiplier": 38.0591,
+      "hpMultiplier": 27.2181,
+      "defMultiplier": 18.8265,
+      "goldCost": 304100000,
+      "crystalCost": 65309
+    },
+    {
+      "level": 1135,
+      "atkMultiplier": 38.1145,
+      "hpMultiplier": 27.2563,
+      "defMultiplier": 18.8519,
+      "goldCost": 305100000,
+      "crystalCost": 65509
+    },
+    {
+      "level": 1136,
+      "atkMultiplier": 38.1699,
+      "hpMultiplier": 27.2946,
+      "defMultiplier": 18.8774,
+      "goldCost": 306100000,
+      "crystalCost": 65709
+    },
+    {
+      "level": 1137,
+      "atkMultiplier": 38.2254,
+      "hpMultiplier": 27.3329,
+      "defMultiplier": 18.9029,
+      "goldCost": 307100000,
+      "crystalCost": 65909
+    },
+    {
+      "level": 1138,
+      "atkMultiplier": 38.2809,
+      "hpMultiplier": 27.3713,
+      "defMultiplier": 18.9284,
+      "goldCost": 308100000,
+      "crystalCost": 66109
+    },
+    {
+      "level": 1139,
+      "atkMultiplier": 38.3364,
+      "hpMultiplier": 27.4096,
+      "defMultiplier": 18.9539,
+      "goldCost": 309100000,
+      "crystalCost": 66309
+    },
+    {
+      "level": 1140,
+      "atkMultiplier": 38.392,
+      "hpMultiplier": 27.448,
+      "defMultiplier": 18.9794,
+      "goldCost": 310100000,
+      "crystalCost": 66509
+    },
+    {
+      "level": 1141,
+      "atkMultiplier": 38.4476,
+      "hpMultiplier": 27.4864,
+      "defMultiplier": 19.005,
+      "goldCost": 311100000,
+      "crystalCost": 66709
+    },
+    {
+      "level": 1142,
+      "atkMultiplier": 38.5033,
+      "hpMultiplier": 27.5249,
+      "defMultiplier": 19.0305,
+      "goldCost": 312100000,
+      "crystalCost": 66909
+    },
+    {
+      "level": 1143,
+      "atkMultiplier": 38.559,
+      "hpMultiplier": 27.5633,
+      "defMultiplier": 19.0561,
+      "goldCost": 313100000,
+      "crystalCost": 67109
+    },
+    {
+      "level": 1144,
+      "atkMultiplier": 38.6147,
+      "hpMultiplier": 27.6018,
+      "defMultiplier": 19.0817,
+      "goldCost": 314100000,
+      "crystalCost": 67309
+    },
+    {
+      "level": 1145,
+      "atkMultiplier": 38.6705,
+      "hpMultiplier": 27.6403,
+      "defMultiplier": 19.1074,
+      "goldCost": 315100000,
+      "crystalCost": 67509
+    },
+    {
+      "level": 1146,
+      "atkMultiplier": 38.7263,
+      "hpMultiplier": 27.6789,
+      "defMultiplier": 19.133,
+      "goldCost": 316100000,
+      "crystalCost": 67709
+    },
+    {
+      "level": 1147,
+      "atkMultiplier": 38.7822,
+      "hpMultiplier": 27.7175,
+      "defMultiplier": 19.1586,
+      "goldCost": 317100000,
+      "crystalCost": 67909
+    },
+    {
+      "level": 1148,
+      "atkMultiplier": 38.8381,
+      "hpMultiplier": 27.7561,
+      "defMultiplier": 19.1843,
+      "goldCost": 318100000,
+      "crystalCost": 68109
+    },
+    {
+      "level": 1149,
+      "atkMultiplier": 38.894,
+      "hpMultiplier": 27.7947,
+      "defMultiplier": 19.21,
+      "goldCost": 319100000,
+      "crystalCost": 68309
+    },
+    {
+      "level": 1150,
+      "atkMultiplier": 38.95,
+      "hpMultiplier": 27.8333,
+      "defMultiplier": 19.2357,
+      "goldCost": 320100000,
+      "crystalCost": 68509
+    },
+    {
+      "level": 1151,
+      "atkMultiplier": 39.006,
+      "hpMultiplier": 27.872,
+      "defMultiplier": 19.2614,
+      "goldCost": 321100000,
+      "crystalCost": 68709
+    },
+    {
+      "level": 1152,
+      "atkMultiplier": 39.0621,
+      "hpMultiplier": 27.9107,
+      "defMultiplier": 19.2872,
+      "goldCost": 322100000,
+      "crystalCost": 68909
+    },
+    {
+      "level": 1153,
+      "atkMultiplier": 39.1182,
+      "hpMultiplier": 27.9495,
+      "defMultiplier": 19.3129,
+      "goldCost": 323100000,
+      "crystalCost": 69109
+    },
+    {
+      "level": 1154,
+      "atkMultiplier": 39.1743,
+      "hpMultiplier": 27.9882,
+      "defMultiplier": 19.3387,
+      "goldCost": 324100000,
+      "crystalCost": 69309
+    },
+    {
+      "level": 1155,
+      "atkMultiplier": 39.2305,
+      "hpMultiplier": 28.027,
+      "defMultiplier": 19.3645,
+      "goldCost": 325100000,
+      "crystalCost": 69509
+    },
+    {
+      "level": 1156,
+      "atkMultiplier": 39.2867,
+      "hpMultiplier": 28.0658,
+      "defMultiplier": 19.3903,
+      "goldCost": 326100000,
+      "crystalCost": 69709
+    },
+    {
+      "level": 1157,
+      "atkMultiplier": 39.343,
+      "hpMultiplier": 28.1047,
+      "defMultiplier": 19.4161,
+      "goldCost": 327100000,
+      "crystalCost": 69909
+    },
+    {
+      "level": 1158,
+      "atkMultiplier": 39.3993,
+      "hpMultiplier": 28.1435,
+      "defMultiplier": 19.442,
+      "goldCost": 328100000,
+      "crystalCost": 70109
+    },
+    {
+      "level": 1159,
+      "atkMultiplier": 39.4556,
+      "hpMultiplier": 28.1824,
+      "defMultiplier": 19.4678,
+      "goldCost": 329100000,
+      "crystalCost": 70309
+    },
+    {
+      "level": 1160,
+      "atkMultiplier": 39.512,
+      "hpMultiplier": 28.2213,
+      "defMultiplier": 19.4937,
+      "goldCost": 330100000,
+      "crystalCost": 70509
+    },
+    {
+      "level": 1161,
+      "atkMultiplier": 39.5684,
+      "hpMultiplier": 28.2603,
+      "defMultiplier": 19.5196,
+      "goldCost": 331100000,
+      "crystalCost": 70709
+    },
+    {
+      "level": 1162,
+      "atkMultiplier": 39.6249,
+      "hpMultiplier": 28.2993,
+      "defMultiplier": 19.5455,
+      "goldCost": 332100000,
+      "crystalCost": 70909
+    },
+    {
+      "level": 1163,
+      "atkMultiplier": 39.6814,
+      "hpMultiplier": 28.3383,
+      "defMultiplier": 19.5714,
+      "goldCost": 333100000,
+      "crystalCost": 71109
+    },
+    {
+      "level": 1164,
+      "atkMultiplier": 39.7379,
+      "hpMultiplier": 28.3773,
+      "defMultiplier": 19.5974,
+      "goldCost": 334100000,
+      "crystalCost": 71309
+    },
+    {
+      "level": 1165,
+      "atkMultiplier": 39.7945,
+      "hpMultiplier": 28.4163,
+      "defMultiplier": 19.6234,
+      "goldCost": 335100000,
+      "crystalCost": 71509
+    },
+    {
+      "level": 1166,
+      "atkMultiplier": 39.8511,
+      "hpMultiplier": 28.4554,
+      "defMultiplier": 19.6493,
+      "goldCost": 336100000,
+      "crystalCost": 71709
+    },
+    {
+      "level": 1167,
+      "atkMultiplier": 39.9078,
+      "hpMultiplier": 28.4945,
+      "defMultiplier": 19.6753,
+      "goldCost": 337100000,
+      "crystalCost": 71909
+    },
+    {
+      "level": 1168,
+      "atkMultiplier": 39.9645,
+      "hpMultiplier": 28.5337,
+      "defMultiplier": 19.7013,
+      "goldCost": 338100000,
+      "crystalCost": 72109
+    },
+    {
+      "level": 1169,
+      "atkMultiplier": 40.0212,
+      "hpMultiplier": 28.5728,
+      "defMultiplier": 19.7274,
+      "goldCost": 339100000,
+      "crystalCost": 72309
+    },
+    {
+      "level": 1170,
+      "atkMultiplier": 40.078,
+      "hpMultiplier": 28.612,
+      "defMultiplier": 19.7534,
+      "goldCost": 340100000,
+      "crystalCost": 72509
+    },
+    {
+      "level": 1171,
+      "atkMultiplier": 40.1348,
+      "hpMultiplier": 28.6512,
+      "defMultiplier": 19.7795,
+      "goldCost": 341100000,
+      "crystalCost": 72709
+    },
+    {
+      "level": 1172,
+      "atkMultiplier": 40.1917,
+      "hpMultiplier": 28.6905,
+      "defMultiplier": 19.8056,
+      "goldCost": 342100000,
+      "crystalCost": 72909
+    },
+    {
+      "level": 1173,
+      "atkMultiplier": 40.2486,
+      "hpMultiplier": 28.7297,
+      "defMultiplier": 19.8317,
+      "goldCost": 343100000,
+      "crystalCost": 73109
+    },
+    {
+      "level": 1174,
+      "atkMultiplier": 40.3055,
+      "hpMultiplier": 28.769,
+      "defMultiplier": 19.8578,
+      "goldCost": 344100000,
+      "crystalCost": 73309
+    },
+    {
+      "level": 1175,
+      "atkMultiplier": 40.3625,
+      "hpMultiplier": 28.8083,
+      "defMultiplier": 19.8839,
+      "goldCost": 345100000,
+      "crystalCost": 73509
+    },
+    {
+      "level": 1176,
+      "atkMultiplier": 40.4195,
+      "hpMultiplier": 28.8477,
+      "defMultiplier": 19.9101,
+      "goldCost": 346100000,
+      "crystalCost": 73709
+    },
+    {
+      "level": 1177,
+      "atkMultiplier": 40.4766,
+      "hpMultiplier": 28.8871,
+      "defMultiplier": 19.9362,
+      "goldCost": 347100000,
+      "crystalCost": 73909
+    },
+    {
+      "level": 1178,
+      "atkMultiplier": 40.5337,
+      "hpMultiplier": 28.9265,
+      "defMultiplier": 19.9624,
+      "goldCost": 348100000,
+      "crystalCost": 74109
+    },
+    {
+      "level": 1179,
+      "atkMultiplier": 40.5908,
+      "hpMultiplier": 28.9659,
+      "defMultiplier": 19.9886,
+      "goldCost": 349100000,
+      "crystalCost": 74309
+    },
+    {
+      "level": 1180,
+      "atkMultiplier": 40.648,
+      "hpMultiplier": 29.0053,
+      "defMultiplier": 20.0149,
+      "goldCost": 350100000,
+      "crystalCost": 74509
+    },
+    {
+      "level": 1181,
+      "atkMultiplier": 40.7052,
+      "hpMultiplier": 29.0448,
+      "defMultiplier": 20.0411,
+      "goldCost": 351100000,
+      "crystalCost": 74709
+    },
+    {
+      "level": 1182,
+      "atkMultiplier": 40.7625,
+      "hpMultiplier": 29.0843,
+      "defMultiplier": 20.0673,
+      "goldCost": 352100000,
+      "crystalCost": 74909
+    },
+    {
+      "level": 1183,
+      "atkMultiplier": 40.8198,
+      "hpMultiplier": 29.1239,
+      "defMultiplier": 20.0936,
+      "goldCost": 353100000,
+      "crystalCost": 75109
+    },
+    {
+      "level": 1184,
+      "atkMultiplier": 40.8771,
+      "hpMultiplier": 29.1634,
+      "defMultiplier": 20.1199,
+      "goldCost": 354100000,
+      "crystalCost": 75309
+    },
+    {
+      "level": 1185,
+      "atkMultiplier": 40.9345,
+      "hpMultiplier": 29.203,
+      "defMultiplier": 20.1462,
+      "goldCost": 355100000,
+      "crystalCost": 75509
+    },
+    {
+      "level": 1186,
+      "atkMultiplier": 40.9919,
+      "hpMultiplier": 29.2426,
+      "defMultiplier": 20.1725,
+      "goldCost": 356100000,
+      "crystalCost": 75709
+    },
+    {
+      "level": 1187,
+      "atkMultiplier": 41.0494,
+      "hpMultiplier": 29.2823,
+      "defMultiplier": 20.1989,
+      "goldCost": 357100000,
+      "crystalCost": 75909
+    },
+    {
+      "level": 1188,
+      "atkMultiplier": 41.1069,
+      "hpMultiplier": 29.3219,
+      "defMultiplier": 20.2252,
+      "goldCost": 358100000,
+      "crystalCost": 76109
+    },
+    {
+      "level": 1189,
+      "atkMultiplier": 41.1644,
+      "hpMultiplier": 29.3616,
+      "defMultiplier": 20.2516,
+      "goldCost": 359100000,
+      "crystalCost": 76309
+    },
+    {
+      "level": 1190,
+      "atkMultiplier": 41.222,
+      "hpMultiplier": 29.4013,
+      "defMultiplier": 20.278,
+      "goldCost": 360100000,
+      "crystalCost": 76509
+    },
+    {
+      "level": 1191,
+      "atkMultiplier": 41.2796,
+      "hpMultiplier": 29.4411,
+      "defMultiplier": 20.3044,
+      "goldCost": 361100000,
+      "crystalCost": 76709
+    },
+    {
+      "level": 1192,
+      "atkMultiplier": 41.3373,
+      "hpMultiplier": 29.4809,
+      "defMultiplier": 20.3308,
+      "goldCost": 362100000,
+      "crystalCost": 76909
+    },
+    {
+      "level": 1193,
+      "atkMultiplier": 41.395,
+      "hpMultiplier": 29.5207,
+      "defMultiplier": 20.3573,
+      "goldCost": 363100000,
+      "crystalCost": 77109
+    },
+    {
+      "level": 1194,
+      "atkMultiplier": 41.4527,
+      "hpMultiplier": 29.5605,
+      "defMultiplier": 20.3837,
+      "goldCost": 364100000,
+      "crystalCost": 77309
+    },
+    {
+      "level": 1195,
+      "atkMultiplier": 41.5105,
+      "hpMultiplier": 29.6003,
+      "defMultiplier": 20.4102,
+      "goldCost": 365100000,
+      "crystalCost": 77509
+    },
+    {
+      "level": 1196,
+      "atkMultiplier": 41.5683,
+      "hpMultiplier": 29.6402,
+      "defMultiplier": 20.4367,
+      "goldCost": 366100000,
+      "crystalCost": 77709
+    },
+    {
+      "level": 1197,
+      "atkMultiplier": 41.6262,
+      "hpMultiplier": 29.6801,
+      "defMultiplier": 20.4632,
+      "goldCost": 367100000,
+      "crystalCost": 77909
+    },
+    {
+      "level": 1198,
+      "atkMultiplier": 41.6841,
+      "hpMultiplier": 29.7201,
+      "defMultiplier": 20.4897,
+      "goldCost": 368100000,
+      "crystalCost": 78109
+    },
+    {
+      "level": 1199,
+      "atkMultiplier": 41.742,
+      "hpMultiplier": 29.76,
+      "defMultiplier": 20.5163,
+      "goldCost": 369100000,
+      "crystalCost": 78309
+    },
+    {
+      "level": 1200,
+      "atkMultiplier": 41.8,
+      "hpMultiplier": 29.8,
+      "defMultiplier": 20.5429,
+      "goldCost": 370100000,
+      "crystalCost": 78509
+    },
+    {
+      "level": 1201,
+      "atkMultiplier": 41.858,
+      "hpMultiplier": 29.84,
+      "defMultiplier": 20.5694,
+      "goldCost": 375100000,
+      "crystalCost": 79009
+    },
+    {
+      "level": 1202,
+      "atkMultiplier": 41.9161,
+      "hpMultiplier": 29.8801,
+      "defMultiplier": 20.596,
+      "goldCost": 380100000,
+      "crystalCost": 79509
+    },
+    {
+      "level": 1203,
+      "atkMultiplier": 41.9742,
+      "hpMultiplier": 29.9201,
+      "defMultiplier": 20.6226,
+      "goldCost": 385100000,
+      "crystalCost": 80009
+    },
+    {
+      "level": 1204,
+      "atkMultiplier": 42.0323,
+      "hpMultiplier": 29.9602,
+      "defMultiplier": 20.6493,
+      "goldCost": 390100000,
+      "crystalCost": 80509
+    },
+    {
+      "level": 1205,
+      "atkMultiplier": 42.0905,
+      "hpMultiplier": 30.0003,
+      "defMultiplier": 20.6759,
+      "goldCost": 395100000,
+      "crystalCost": 81009
+    },
+    {
+      "level": 1206,
+      "atkMultiplier": 42.1487,
+      "hpMultiplier": 30.0405,
+      "defMultiplier": 20.7026,
+      "goldCost": 400100000,
+      "crystalCost": 81509
+    },
+    {
+      "level": 1207,
+      "atkMultiplier": 42.207,
+      "hpMultiplier": 30.0807,
+      "defMultiplier": 20.7293,
+      "goldCost": 405100000,
+      "crystalCost": 82009
+    },
+    {
+      "level": 1208,
+      "atkMultiplier": 42.2653,
+      "hpMultiplier": 30.1209,
+      "defMultiplier": 20.756,
+      "goldCost": 410100000,
+      "crystalCost": 82509
+    },
+    {
+      "level": 1209,
+      "atkMultiplier": 42.3236,
+      "hpMultiplier": 30.1611,
+      "defMultiplier": 20.7827,
+      "goldCost": 415100000,
+      "crystalCost": 83009
+    },
+    {
+      "level": 1210,
+      "atkMultiplier": 42.382,
+      "hpMultiplier": 30.2013,
+      "defMultiplier": 20.8094,
+      "goldCost": 420100000,
+      "crystalCost": 83509
+    },
+    {
+      "level": 1211,
+      "atkMultiplier": 42.4404,
+      "hpMultiplier": 30.2416,
+      "defMultiplier": 20.8362,
+      "goldCost": 425100000,
+      "crystalCost": 84009
+    },
+    {
+      "level": 1212,
+      "atkMultiplier": 42.4989,
+      "hpMultiplier": 30.2819,
+      "defMultiplier": 20.8629,
+      "goldCost": 430100000,
+      "crystalCost": 84509
+    },
+    {
+      "level": 1213,
+      "atkMultiplier": 42.5574,
+      "hpMultiplier": 30.3223,
+      "defMultiplier": 20.8897,
+      "goldCost": 435100000,
+      "crystalCost": 85009
+    },
+    {
+      "level": 1214,
+      "atkMultiplier": 42.6159,
+      "hpMultiplier": 30.3626,
+      "defMultiplier": 20.9165,
+      "goldCost": 440100000,
+      "crystalCost": 85509
+    },
+    {
+      "level": 1215,
+      "atkMultiplier": 42.6745,
+      "hpMultiplier": 30.403,
+      "defMultiplier": 20.9434,
+      "goldCost": 445100000,
+      "crystalCost": 86009
+    },
+    {
+      "level": 1216,
+      "atkMultiplier": 42.7331,
+      "hpMultiplier": 30.4434,
+      "defMultiplier": 20.9702,
+      "goldCost": 450100000,
+      "crystalCost": 86509
+    },
+    {
+      "level": 1217,
+      "atkMultiplier": 42.7918,
+      "hpMultiplier": 30.4839,
+      "defMultiplier": 20.997,
+      "goldCost": 455100000,
+      "crystalCost": 87009
+    },
+    {
+      "level": 1218,
+      "atkMultiplier": 42.8505,
+      "hpMultiplier": 30.5243,
+      "defMultiplier": 21.0239,
+      "goldCost": 460100000,
+      "crystalCost": 87509
+    },
+    {
+      "level": 1219,
+      "atkMultiplier": 42.9092,
+      "hpMultiplier": 30.5648,
+      "defMultiplier": 21.0508,
+      "goldCost": 465100000,
+      "crystalCost": 88009
+    },
+    {
+      "level": 1220,
+      "atkMultiplier": 42.968,
+      "hpMultiplier": 30.6053,
+      "defMultiplier": 21.0777,
+      "goldCost": 470100000,
+      "crystalCost": 88509
+    },
+    {
+      "level": 1221,
+      "atkMultiplier": 43.0268,
+      "hpMultiplier": 30.6459,
+      "defMultiplier": 21.1046,
+      "goldCost": 475100000,
+      "crystalCost": 89009
+    },
+    {
+      "level": 1222,
+      "atkMultiplier": 43.0857,
+      "hpMultiplier": 30.6865,
+      "defMultiplier": 21.1316,
+      "goldCost": 480100000,
+      "crystalCost": 89509
+    },
+    {
+      "level": 1223,
+      "atkMultiplier": 43.1446,
+      "hpMultiplier": 30.7271,
+      "defMultiplier": 21.1585,
+      "goldCost": 485100000,
+      "crystalCost": 90009
+    },
+    {
+      "level": 1224,
+      "atkMultiplier": 43.2035,
+      "hpMultiplier": 30.7677,
+      "defMultiplier": 21.1855,
+      "goldCost": 490100000,
+      "crystalCost": 90509
+    },
+    {
+      "level": 1225,
+      "atkMultiplier": 43.2625,
+      "hpMultiplier": 30.8083,
+      "defMultiplier": 21.2125,
+      "goldCost": 495100000,
+      "crystalCost": 91009
+    },
+    {
+      "level": 1226,
+      "atkMultiplier": 43.3215,
+      "hpMultiplier": 30.849,
+      "defMultiplier": 21.2395,
+      "goldCost": 500100000,
+      "crystalCost": 91509
+    },
+    {
+      "level": 1227,
+      "atkMultiplier": 43.3806,
+      "hpMultiplier": 30.8897,
+      "defMultiplier": 21.2665,
+      "goldCost": 505100000,
+      "crystalCost": 92009
+    },
+    {
+      "level": 1228,
+      "atkMultiplier": 43.4397,
+      "hpMultiplier": 30.9305,
+      "defMultiplier": 21.2936,
+      "goldCost": 510100000,
+      "crystalCost": 92509
+    },
+    {
+      "level": 1229,
+      "atkMultiplier": 43.4988,
+      "hpMultiplier": 30.9712,
+      "defMultiplier": 21.3206,
+      "goldCost": 515100000,
+      "crystalCost": 93009
+    },
+    {
+      "level": 1230,
+      "atkMultiplier": 43.558,
+      "hpMultiplier": 31.012,
+      "defMultiplier": 21.3477,
+      "goldCost": 520100000,
+      "crystalCost": 93509
+    },
+    {
+      "level": 1231,
+      "atkMultiplier": 43.6172,
+      "hpMultiplier": 31.0528,
+      "defMultiplier": 21.3748,
+      "goldCost": 525100000,
+      "crystalCost": 94009
+    },
+    {
+      "level": 1232,
+      "atkMultiplier": 43.6765,
+      "hpMultiplier": 31.0937,
+      "defMultiplier": 21.4019,
+      "goldCost": 530100000,
+      "crystalCost": 94509
+    },
+    {
+      "level": 1233,
+      "atkMultiplier": 43.7358,
+      "hpMultiplier": 31.1345,
+      "defMultiplier": 21.429,
+      "goldCost": 535100000,
+      "crystalCost": 95009
+    },
+    {
+      "level": 1234,
+      "atkMultiplier": 43.7951,
+      "hpMultiplier": 31.1754,
+      "defMultiplier": 21.4562,
+      "goldCost": 540100000,
+      "crystalCost": 95509
+    },
+    {
+      "level": 1235,
+      "atkMultiplier": 43.8545,
+      "hpMultiplier": 31.2163,
+      "defMultiplier": 21.4834,
+      "goldCost": 545100000,
+      "crystalCost": 96009
+    },
+    {
+      "level": 1236,
+      "atkMultiplier": 43.9139,
+      "hpMultiplier": 31.2573,
+      "defMultiplier": 21.5105,
+      "goldCost": 550100000,
+      "crystalCost": 96509
+    },
+    {
+      "level": 1237,
+      "atkMultiplier": 43.9734,
+      "hpMultiplier": 31.2983,
+      "defMultiplier": 21.5377,
+      "goldCost": 555100000,
+      "crystalCost": 97009
+    },
+    {
+      "level": 1238,
+      "atkMultiplier": 44.0329,
+      "hpMultiplier": 31.3393,
+      "defMultiplier": 21.5649,
+      "goldCost": 560100000,
+      "crystalCost": 97509
+    },
+    {
+      "level": 1239,
+      "atkMultiplier": 44.0924,
+      "hpMultiplier": 31.3803,
+      "defMultiplier": 21.5922,
+      "goldCost": 565100000,
+      "crystalCost": 98009
+    },
+    {
+      "level": 1240,
+      "atkMultiplier": 44.152,
+      "hpMultiplier": 31.4213,
+      "defMultiplier": 21.6194,
+      "goldCost": 570100000,
+      "crystalCost": 98509
+    },
+    {
+      "level": 1241,
+      "atkMultiplier": 44.2116,
+      "hpMultiplier": 31.4624,
+      "defMultiplier": 21.6467,
+      "goldCost": 575100000,
+      "crystalCost": 99009
+    },
+    {
+      "level": 1242,
+      "atkMultiplier": 44.2713,
+      "hpMultiplier": 31.5035,
+      "defMultiplier": 21.674,
+      "goldCost": 580100000,
+      "crystalCost": 99509
+    },
+    {
+      "level": 1243,
+      "atkMultiplier": 44.331,
+      "hpMultiplier": 31.5447,
+      "defMultiplier": 21.7013,
+      "goldCost": 585100000,
+      "crystalCost": 100009
+    },
+    {
+      "level": 1244,
+      "atkMultiplier": 44.3907,
+      "hpMultiplier": 31.5858,
+      "defMultiplier": 21.7286,
+      "goldCost": 590100000,
+      "crystalCost": 100509
+    },
+    {
+      "level": 1245,
+      "atkMultiplier": 44.4505,
+      "hpMultiplier": 31.627,
+      "defMultiplier": 21.7559,
+      "goldCost": 595100000,
+      "crystalCost": 101009
+    },
+    {
+      "level": 1246,
+      "atkMultiplier": 44.5103,
+      "hpMultiplier": 31.6682,
+      "defMultiplier": 21.7833,
+      "goldCost": 600100000,
+      "crystalCost": 101509
+    },
+    {
+      "level": 1247,
+      "atkMultiplier": 44.5702,
+      "hpMultiplier": 31.7095,
+      "defMultiplier": 21.8106,
+      "goldCost": 605100000,
+      "crystalCost": 102009
+    },
+    {
+      "level": 1248,
+      "atkMultiplier": 44.6301,
+      "hpMultiplier": 31.7507,
+      "defMultiplier": 21.838,
+      "goldCost": 610100000,
+      "crystalCost": 102509
+    },
+    {
+      "level": 1249,
+      "atkMultiplier": 44.69,
+      "hpMultiplier": 31.792,
+      "defMultiplier": 21.8654,
+      "goldCost": 615100000,
+      "crystalCost": 103009
+    },
+    {
+      "level": 1250,
+      "atkMultiplier": 44.75,
+      "hpMultiplier": 31.8333,
+      "defMultiplier": 21.8929,
+      "goldCost": 620100000,
+      "crystalCost": 103509
+    },
+    {
+      "level": 1251,
+      "atkMultiplier": 44.81,
+      "hpMultiplier": 31.8747,
+      "defMultiplier": 21.9203,
+      "goldCost": 625100000,
+      "crystalCost": 104009
+    },
+    {
+      "level": 1252,
+      "atkMultiplier": 44.8701,
+      "hpMultiplier": 31.9161,
+      "defMultiplier": 21.9477,
+      "goldCost": 630100000,
+      "crystalCost": 104509
+    },
+    {
+      "level": 1253,
+      "atkMultiplier": 44.9302,
+      "hpMultiplier": 31.9575,
+      "defMultiplier": 21.9752,
+      "goldCost": 635100000,
+      "crystalCost": 105009
+    },
+    {
+      "level": 1254,
+      "atkMultiplier": 44.9903,
+      "hpMultiplier": 31.9989,
+      "defMultiplier": 22.0027,
+      "goldCost": 640100000,
+      "crystalCost": 105509
+    },
+    {
+      "level": 1255,
+      "atkMultiplier": 45.0505,
+      "hpMultiplier": 32.0403,
+      "defMultiplier": 22.0302,
+      "goldCost": 645100000,
+      "crystalCost": 106009
+    },
+    {
+      "level": 1256,
+      "atkMultiplier": 45.1107,
+      "hpMultiplier": 32.0818,
+      "defMultiplier": 22.0577,
+      "goldCost": 650100000,
+      "crystalCost": 106509
+    },
+    {
+      "level": 1257,
+      "atkMultiplier": 45.171,
+      "hpMultiplier": 32.1233,
+      "defMultiplier": 22.0853,
+      "goldCost": 655100000,
+      "crystalCost": 107009
+    },
+    {
+      "level": 1258,
+      "atkMultiplier": 45.2313,
+      "hpMultiplier": 32.1649,
+      "defMultiplier": 22.1128,
+      "goldCost": 660100000,
+      "crystalCost": 107509
+    },
+    {
+      "level": 1259,
+      "atkMultiplier": 45.2916,
+      "hpMultiplier": 32.2064,
+      "defMultiplier": 22.1404,
+      "goldCost": 665100000,
+      "crystalCost": 108009
+    },
+    {
+      "level": 1260,
+      "atkMultiplier": 45.352,
+      "hpMultiplier": 32.248,
+      "defMultiplier": 22.168,
+      "goldCost": 670100000,
+      "crystalCost": 108509
+    },
+    {
+      "level": 1261,
+      "atkMultiplier": 45.4124,
+      "hpMultiplier": 32.2896,
+      "defMultiplier": 22.1956,
+      "goldCost": 675100000,
+      "crystalCost": 109009
+    },
+    {
+      "level": 1262,
+      "atkMultiplier": 45.4729,
+      "hpMultiplier": 32.3313,
+      "defMultiplier": 22.2232,
+      "goldCost": 680100000,
+      "crystalCost": 109509
+    },
+    {
+      "level": 1263,
+      "atkMultiplier": 45.5334,
+      "hpMultiplier": 32.3729,
+      "defMultiplier": 22.2509,
+      "goldCost": 685100000,
+      "crystalCost": 110009
+    },
+    {
+      "level": 1264,
+      "atkMultiplier": 45.5939,
+      "hpMultiplier": 32.4146,
+      "defMultiplier": 22.2785,
+      "goldCost": 690100000,
+      "crystalCost": 110509
+    },
+    {
+      "level": 1265,
+      "atkMultiplier": 45.6545,
+      "hpMultiplier": 32.4563,
+      "defMultiplier": 22.3062,
+      "goldCost": 695100000,
+      "crystalCost": 111009
+    },
+    {
+      "level": 1266,
+      "atkMultiplier": 45.7151,
+      "hpMultiplier": 32.4981,
+      "defMultiplier": 22.3339,
+      "goldCost": 700100000,
+      "crystalCost": 111509
+    },
+    {
+      "level": 1267,
+      "atkMultiplier": 45.7758,
+      "hpMultiplier": 32.5399,
+      "defMultiplier": 22.3616,
+      "goldCost": 705100000,
+      "crystalCost": 112009
+    },
+    {
+      "level": 1268,
+      "atkMultiplier": 45.8365,
+      "hpMultiplier": 32.5817,
+      "defMultiplier": 22.3893,
+      "goldCost": 710100000,
+      "crystalCost": 112509
+    },
+    {
+      "level": 1269,
+      "atkMultiplier": 45.8972,
+      "hpMultiplier": 32.6235,
+      "defMultiplier": 22.4171,
+      "goldCost": 715100000,
+      "crystalCost": 113009
+    },
+    {
+      "level": 1270,
+      "atkMultiplier": 45.958,
+      "hpMultiplier": 32.6653,
+      "defMultiplier": 22.4449,
+      "goldCost": 720100000,
+      "crystalCost": 113509
+    },
+    {
+      "level": 1271,
+      "atkMultiplier": 46.0188,
+      "hpMultiplier": 32.7072,
+      "defMultiplier": 22.4726,
+      "goldCost": 725100000,
+      "crystalCost": 114009
+    },
+    {
+      "level": 1272,
+      "atkMultiplier": 46.0797,
+      "hpMultiplier": 32.7491,
+      "defMultiplier": 22.5004,
+      "goldCost": 730100000,
+      "crystalCost": 114509
+    },
+    {
+      "level": 1273,
+      "atkMultiplier": 46.1406,
+      "hpMultiplier": 32.7911,
+      "defMultiplier": 22.5282,
+      "goldCost": 735100000,
+      "crystalCost": 115009
+    },
+    {
+      "level": 1274,
+      "atkMultiplier": 46.2015,
+      "hpMultiplier": 32.833,
+      "defMultiplier": 22.5561,
+      "goldCost": 740100000,
+      "crystalCost": 115509
+    },
+    {
+      "level": 1275,
+      "atkMultiplier": 46.2625,
+      "hpMultiplier": 32.875,
+      "defMultiplier": 22.5839,
+      "goldCost": 745100000,
+      "crystalCost": 116009
+    },
+    {
+      "level": 1276,
+      "atkMultiplier": 46.3235,
+      "hpMultiplier": 32.917,
+      "defMultiplier": 22.6118,
+      "goldCost": 750100000,
+      "crystalCost": 116509
+    },
+    {
+      "level": 1277,
+      "atkMultiplier": 46.3846,
+      "hpMultiplier": 32.9591,
+      "defMultiplier": 22.6397,
+      "goldCost": 755100000,
+      "crystalCost": 117009
+    },
+    {
+      "level": 1278,
+      "atkMultiplier": 46.4457,
+      "hpMultiplier": 33.0011,
+      "defMultiplier": 22.6676,
+      "goldCost": 760100000,
+      "crystalCost": 117509
+    },
+    {
+      "level": 1279,
+      "atkMultiplier": 46.5068,
+      "hpMultiplier": 33.0432,
+      "defMultiplier": 22.6955,
+      "goldCost": 765100000,
+      "crystalCost": 118009
+    },
+    {
+      "level": 1280,
+      "atkMultiplier": 46.568,
+      "hpMultiplier": 33.0853,
+      "defMultiplier": 22.7234,
+      "goldCost": 770100000,
+      "crystalCost": 118509
+    },
+    {
+      "level": 1281,
+      "atkMultiplier": 46.6292,
+      "hpMultiplier": 33.1275,
+      "defMultiplier": 22.7514,
+      "goldCost": 775100000,
+      "crystalCost": 119009
+    },
+    {
+      "level": 1282,
+      "atkMultiplier": 46.6905,
+      "hpMultiplier": 33.1697,
+      "defMultiplier": 22.7793,
+      "goldCost": 780100000,
+      "crystalCost": 119509
+    },
+    {
+      "level": 1283,
+      "atkMultiplier": 46.7518,
+      "hpMultiplier": 33.2119,
+      "defMultiplier": 22.8073,
+      "goldCost": 785100000,
+      "crystalCost": 120009
+    },
+    {
+      "level": 1284,
+      "atkMultiplier": 46.8131,
+      "hpMultiplier": 33.2541,
+      "defMultiplier": 22.8353,
+      "goldCost": 790100000,
+      "crystalCost": 120509
+    },
+    {
+      "level": 1285,
+      "atkMultiplier": 46.8745,
+      "hpMultiplier": 33.2963,
+      "defMultiplier": 22.8634,
+      "goldCost": 795100000,
+      "crystalCost": 121009
+    },
+    {
+      "level": 1286,
+      "atkMultiplier": 46.9359,
+      "hpMultiplier": 33.3386,
+      "defMultiplier": 22.8914,
+      "goldCost": 800100000,
+      "crystalCost": 121509
+    },
+    {
+      "level": 1287,
+      "atkMultiplier": 46.9974,
+      "hpMultiplier": 33.3809,
+      "defMultiplier": 22.9194,
+      "goldCost": 805100000,
+      "crystalCost": 122009
+    },
+    {
+      "level": 1288,
+      "atkMultiplier": 47.0589,
+      "hpMultiplier": 33.4233,
+      "defMultiplier": 22.9475,
+      "goldCost": 810100000,
+      "crystalCost": 122509
+    },
+    {
+      "level": 1289,
+      "atkMultiplier": 47.1204,
+      "hpMultiplier": 33.4656,
+      "defMultiplier": 22.9756,
+      "goldCost": 815100000,
+      "crystalCost": 123009
+    },
+    {
+      "level": 1290,
+      "atkMultiplier": 47.182,
+      "hpMultiplier": 33.508,
+      "defMultiplier": 23.0037,
+      "goldCost": 820100000,
+      "crystalCost": 123509
+    },
+    {
+      "level": 1291,
+      "atkMultiplier": 47.2436,
+      "hpMultiplier": 33.5504,
+      "defMultiplier": 23.0318,
+      "goldCost": 825100000,
+      "crystalCost": 124009
+    },
+    {
+      "level": 1292,
+      "atkMultiplier": 47.3053,
+      "hpMultiplier": 33.5929,
+      "defMultiplier": 23.06,
+      "goldCost": 830100000,
+      "crystalCost": 124509
+    },
+    {
+      "level": 1293,
+      "atkMultiplier": 47.367,
+      "hpMultiplier": 33.6353,
+      "defMultiplier": 23.0881,
+      "goldCost": 835100000,
+      "crystalCost": 125009
+    },
+    {
+      "level": 1294,
+      "atkMultiplier": 47.4287,
+      "hpMultiplier": 33.6778,
+      "defMultiplier": 23.1163,
+      "goldCost": 840100000,
+      "crystalCost": 125509
+    },
+    {
+      "level": 1295,
+      "atkMultiplier": 47.4905,
+      "hpMultiplier": 33.7203,
+      "defMultiplier": 23.1445,
+      "goldCost": 845100000,
+      "crystalCost": 126009
+    },
+    {
+      "level": 1296,
+      "atkMultiplier": 47.5523,
+      "hpMultiplier": 33.7629,
+      "defMultiplier": 23.1727,
+      "goldCost": 850100000,
+      "crystalCost": 126509
+    },
+    {
+      "level": 1297,
+      "atkMultiplier": 47.6142,
+      "hpMultiplier": 33.8055,
+      "defMultiplier": 23.2009,
+      "goldCost": 855100000,
+      "crystalCost": 127009
+    },
+    {
+      "level": 1298,
+      "atkMultiplier": 47.6761,
+      "hpMultiplier": 33.8481,
+      "defMultiplier": 23.2292,
+      "goldCost": 860100000,
+      "crystalCost": 127509
+    },
+    {
+      "level": 1299,
+      "atkMultiplier": 47.738,
+      "hpMultiplier": 33.8907,
+      "defMultiplier": 23.2574,
+      "goldCost": 865100000,
+      "crystalCost": 128009
+    },
+    {
+      "level": 1300,
+      "atkMultiplier": 47.8,
+      "hpMultiplier": 33.9333,
+      "defMultiplier": 23.2857,
+      "goldCost": 870100000,
+      "crystalCost": 128509
+    },
+    {
+      "level": 1301,
+      "atkMultiplier": 47.862,
+      "hpMultiplier": 33.976,
+      "defMultiplier": 23.314,
+      "goldCost": 875100000,
+      "crystalCost": 129009
+    },
+    {
+      "level": 1302,
+      "atkMultiplier": 47.9241,
+      "hpMultiplier": 34.0187,
+      "defMultiplier": 23.3423,
+      "goldCost": 880100000,
+      "crystalCost": 129509
+    },
+    {
+      "level": 1303,
+      "atkMultiplier": 47.9862,
+      "hpMultiplier": 34.0615,
+      "defMultiplier": 23.3706,
+      "goldCost": 885100000,
+      "crystalCost": 130009
+    },
+    {
+      "level": 1304,
+      "atkMultiplier": 48.0483,
+      "hpMultiplier": 34.1042,
+      "defMultiplier": 23.399,
+      "goldCost": 890100000,
+      "crystalCost": 130509
+    },
+    {
+      "level": 1305,
+      "atkMultiplier": 48.1105,
+      "hpMultiplier": 34.147,
+      "defMultiplier": 23.4274,
+      "goldCost": 895100000,
+      "crystalCost": 131009
+    },
+    {
+      "level": 1306,
+      "atkMultiplier": 48.1727,
+      "hpMultiplier": 34.1898,
+      "defMultiplier": 23.4557,
+      "goldCost": 900100000,
+      "crystalCost": 131509
+    },
+    {
+      "level": 1307,
+      "atkMultiplier": 48.235,
+      "hpMultiplier": 34.2327,
+      "defMultiplier": 23.4841,
+      "goldCost": 905100000,
+      "crystalCost": 132009
+    },
+    {
+      "level": 1308,
+      "atkMultiplier": 48.2973,
+      "hpMultiplier": 34.2755,
+      "defMultiplier": 23.5125,
+      "goldCost": 910100000,
+      "crystalCost": 132509
+    },
+    {
+      "level": 1309,
+      "atkMultiplier": 48.3596,
+      "hpMultiplier": 34.3184,
+      "defMultiplier": 23.541,
+      "goldCost": 915100000,
+      "crystalCost": 133009
+    },
+    {
+      "level": 1310,
+      "atkMultiplier": 48.422,
+      "hpMultiplier": 34.3613,
+      "defMultiplier": 23.5694,
+      "goldCost": 920100000,
+      "crystalCost": 133509
+    },
+    {
+      "level": 1311,
+      "atkMultiplier": 48.4844,
+      "hpMultiplier": 34.4043,
+      "defMultiplier": 23.5979,
+      "goldCost": 925100000,
+      "crystalCost": 134009
+    },
+    {
+      "level": 1312,
+      "atkMultiplier": 48.5469,
+      "hpMultiplier": 34.4473,
+      "defMultiplier": 23.6264,
+      "goldCost": 930100000,
+      "crystalCost": 134509
+    },
+    {
+      "level": 1313,
+      "atkMultiplier": 48.6094,
+      "hpMultiplier": 34.4903,
+      "defMultiplier": 23.6549,
+      "goldCost": 935100000,
+      "crystalCost": 135009
+    },
+    {
+      "level": 1314,
+      "atkMultiplier": 48.6719,
+      "hpMultiplier": 34.5333,
+      "defMultiplier": 23.6834,
+      "goldCost": 940100000,
+      "crystalCost": 135509
+    },
+    {
+      "level": 1315,
+      "atkMultiplier": 48.7345,
+      "hpMultiplier": 34.5763,
+      "defMultiplier": 23.7119,
+      "goldCost": 945100000,
+      "crystalCost": 136009
+    },
+    {
+      "level": 1316,
+      "atkMultiplier": 48.7971,
+      "hpMultiplier": 34.6194,
+      "defMultiplier": 23.7405,
+      "goldCost": 950100000,
+      "crystalCost": 136509
+    },
+    {
+      "level": 1317,
+      "atkMultiplier": 48.8598,
+      "hpMultiplier": 34.6625,
+      "defMultiplier": 23.769,
+      "goldCost": 955100000,
+      "crystalCost": 137009
+    },
+    {
+      "level": 1318,
+      "atkMultiplier": 48.9225,
+      "hpMultiplier": 34.7057,
+      "defMultiplier": 23.7976,
+      "goldCost": 960100000,
+      "crystalCost": 137509
+    },
+    {
+      "level": 1319,
+      "atkMultiplier": 48.9852,
+      "hpMultiplier": 34.7488,
+      "defMultiplier": 23.8262,
+      "goldCost": 965100000,
+      "crystalCost": 138009
+    },
+    {
+      "level": 1320,
+      "atkMultiplier": 49.048,
+      "hpMultiplier": 34.792,
+      "defMultiplier": 23.8549,
+      "goldCost": 970100000,
+      "crystalCost": 138509
+    },
+    {
+      "level": 1321,
+      "atkMultiplier": 49.1108,
+      "hpMultiplier": 34.8352,
+      "defMultiplier": 23.8835,
+      "goldCost": 975100000,
+      "crystalCost": 139009
+    },
+    {
+      "level": 1322,
+      "atkMultiplier": 49.1737,
+      "hpMultiplier": 34.8785,
+      "defMultiplier": 23.9121,
+      "goldCost": 980100000,
+      "crystalCost": 139509
+    },
+    {
+      "level": 1323,
+      "atkMultiplier": 49.2366,
+      "hpMultiplier": 34.9217,
+      "defMultiplier": 23.9408,
+      "goldCost": 985100000,
+      "crystalCost": 140009
+    },
+    {
+      "level": 1324,
+      "atkMultiplier": 49.2995,
+      "hpMultiplier": 34.965,
+      "defMultiplier": 23.9695,
+      "goldCost": 990100000,
+      "crystalCost": 140509
+    },
+    {
+      "level": 1325,
+      "atkMultiplier": 49.3625,
+      "hpMultiplier": 35.0083,
+      "defMultiplier": 23.9982,
+      "goldCost": 995100000,
+      "crystalCost": 141009
+    },
+    {
+      "level": 1326,
+      "atkMultiplier": 49.4255,
+      "hpMultiplier": 35.0517,
+      "defMultiplier": 24.0269,
+      "goldCost": 1000100000,
+      "crystalCost": 141509
+    },
+    {
+      "level": 1327,
+      "atkMultiplier": 49.4886,
+      "hpMultiplier": 35.0951,
+      "defMultiplier": 24.0557,
+      "goldCost": 1005100000,
+      "crystalCost": 142009
+    },
+    {
+      "level": 1328,
+      "atkMultiplier": 49.5517,
+      "hpMultiplier": 35.1385,
+      "defMultiplier": 24.0844,
+      "goldCost": 1010100000,
+      "crystalCost": 142509
+    },
+    {
+      "level": 1329,
+      "atkMultiplier": 49.6148,
+      "hpMultiplier": 35.1819,
+      "defMultiplier": 24.1132,
+      "goldCost": 1015100000,
+      "crystalCost": 143009
+    },
+    {
+      "level": 1330,
+      "atkMultiplier": 49.678,
+      "hpMultiplier": 35.2253,
+      "defMultiplier": 24.142,
+      "goldCost": 1020100000,
+      "crystalCost": 143509
+    },
+    {
+      "level": 1331,
+      "atkMultiplier": 49.7412,
+      "hpMultiplier": 35.2688,
+      "defMultiplier": 24.1708,
+      "goldCost": 1025100000,
+      "crystalCost": 144009
+    },
+    {
+      "level": 1332,
+      "atkMultiplier": 49.8045,
+      "hpMultiplier": 35.3123,
+      "defMultiplier": 24.1996,
+      "goldCost": 1030100000,
+      "crystalCost": 144509
+    },
+    {
+      "level": 1333,
+      "atkMultiplier": 49.8678,
+      "hpMultiplier": 35.3559,
+      "defMultiplier": 24.2285,
+      "goldCost": 1035100000,
+      "crystalCost": 145009
+    },
+    {
+      "level": 1334,
+      "atkMultiplier": 49.9311,
+      "hpMultiplier": 35.3994,
+      "defMultiplier": 24.2573,
+      "goldCost": 1040100000,
+      "crystalCost": 145509
+    },
+    {
+      "level": 1335,
+      "atkMultiplier": 49.9945,
+      "hpMultiplier": 35.443,
+      "defMultiplier": 24.2862,
+      "goldCost": 1045100000,
+      "crystalCost": 146009
+    },
+    {
+      "level": 1336,
+      "atkMultiplier": 50.0579,
+      "hpMultiplier": 35.4866,
+      "defMultiplier": 24.3151,
+      "goldCost": 1050100000,
+      "crystalCost": 146509
+    },
+    {
+      "level": 1337,
+      "atkMultiplier": 50.1214,
+      "hpMultiplier": 35.5303,
+      "defMultiplier": 24.344,
+      "goldCost": 1055100000,
+      "crystalCost": 147009
+    },
+    {
+      "level": 1338,
+      "atkMultiplier": 50.1849,
+      "hpMultiplier": 35.5739,
+      "defMultiplier": 24.3729,
+      "goldCost": 1060100000,
+      "crystalCost": 147509
+    },
+    {
+      "level": 1339,
+      "atkMultiplier": 50.2484,
+      "hpMultiplier": 35.6176,
+      "defMultiplier": 24.4019,
+      "goldCost": 1065100000,
+      "crystalCost": 148009
+    },
+    {
+      "level": 1340,
+      "atkMultiplier": 50.312,
+      "hpMultiplier": 35.6613,
+      "defMultiplier": 24.4309,
+      "goldCost": 1070100000,
+      "crystalCost": 148509
+    },
+    {
+      "level": 1341,
+      "atkMultiplier": 50.3756,
+      "hpMultiplier": 35.7051,
+      "defMultiplier": 24.4598,
+      "goldCost": 1075100000,
+      "crystalCost": 149009
+    },
+    {
+      "level": 1342,
+      "atkMultiplier": 50.4393,
+      "hpMultiplier": 35.7489,
+      "defMultiplier": 24.4888,
+      "goldCost": 1080100000,
+      "crystalCost": 149509
+    },
+    {
+      "level": 1343,
+      "atkMultiplier": 50.503,
+      "hpMultiplier": 35.7927,
+      "defMultiplier": 24.5178,
+      "goldCost": 1085100000,
+      "crystalCost": 150009
+    },
+    {
+      "level": 1344,
+      "atkMultiplier": 50.5667,
+      "hpMultiplier": 35.8365,
+      "defMultiplier": 24.5469,
+      "goldCost": 1090100000,
+      "crystalCost": 150509
+    },
+    {
+      "level": 1345,
+      "atkMultiplier": 50.6305,
+      "hpMultiplier": 35.8803,
+      "defMultiplier": 24.5759,
+      "goldCost": 1095100000,
+      "crystalCost": 151009
+    },
+    {
+      "level": 1346,
+      "atkMultiplier": 50.6943,
+      "hpMultiplier": 35.9242,
+      "defMultiplier": 24.605,
+      "goldCost": 1100100000,
+      "crystalCost": 151509
+    },
+    {
+      "level": 1347,
+      "atkMultiplier": 50.7582,
+      "hpMultiplier": 35.9681,
+      "defMultiplier": 24.6341,
+      "goldCost": 1105100000,
+      "crystalCost": 152009
+    },
+    {
+      "level": 1348,
+      "atkMultiplier": 50.8221,
+      "hpMultiplier": 36.0121,
+      "defMultiplier": 24.6632,
+      "goldCost": 1110100000,
+      "crystalCost": 152509
+    },
+    {
+      "level": 1349,
+      "atkMultiplier": 50.886,
+      "hpMultiplier": 36.056,
+      "defMultiplier": 24.6923,
+      "goldCost": 1115100000,
+      "crystalCost": 153009
+    },
+    {
+      "level": 1350,
+      "atkMultiplier": 50.95,
+      "hpMultiplier": 36.1,
+      "defMultiplier": 24.7214,
+      "goldCost": 1120100000,
+      "crystalCost": 153509
+    },
+    {
+      "level": 1351,
+      "atkMultiplier": 51.014,
+      "hpMultiplier": 36.144,
+      "defMultiplier": 24.7506,
+      "goldCost": 1125100000,
+      "crystalCost": 154009
+    },
+    {
+      "level": 1352,
+      "atkMultiplier": 51.0781,
+      "hpMultiplier": 36.1881,
+      "defMultiplier": 24.7797,
+      "goldCost": 1130100000,
+      "crystalCost": 154509
+    },
+    {
+      "level": 1353,
+      "atkMultiplier": 51.1422,
+      "hpMultiplier": 36.2321,
+      "defMultiplier": 24.8089,
+      "goldCost": 1135100000,
+      "crystalCost": 155009
+    },
+    {
+      "level": 1354,
+      "atkMultiplier": 51.2063,
+      "hpMultiplier": 36.2762,
+      "defMultiplier": 24.8381,
+      "goldCost": 1140100000,
+      "crystalCost": 155509
+    },
+    {
+      "level": 1355,
+      "atkMultiplier": 51.2705,
+      "hpMultiplier": 36.3203,
+      "defMultiplier": 24.8674,
+      "goldCost": 1145100000,
+      "crystalCost": 156009
+    },
+    {
+      "level": 1356,
+      "atkMultiplier": 51.3347,
+      "hpMultiplier": 36.3645,
+      "defMultiplier": 24.8966,
+      "goldCost": 1150100000,
+      "crystalCost": 156509
+    },
+    {
+      "level": 1357,
+      "atkMultiplier": 51.399,
+      "hpMultiplier": 36.4087,
+      "defMultiplier": 24.9258,
+      "goldCost": 1155100000,
+      "crystalCost": 157009
+    },
+    {
+      "level": 1358,
+      "atkMultiplier": 51.4633,
+      "hpMultiplier": 36.4529,
+      "defMultiplier": 24.9551,
+      "goldCost": 1160100000,
+      "crystalCost": 157509
+    },
+    {
+      "level": 1359,
+      "atkMultiplier": 51.5276,
+      "hpMultiplier": 36.4971,
+      "defMultiplier": 24.9844,
+      "goldCost": 1165100000,
+      "crystalCost": 158009
+    },
+    {
+      "level": 1360,
+      "atkMultiplier": 51.592,
+      "hpMultiplier": 36.5413,
+      "defMultiplier": 25.0137,
+      "goldCost": 1170100000,
+      "crystalCost": 158509
+    },
+    {
+      "level": 1361,
+      "atkMultiplier": 51.6564,
+      "hpMultiplier": 36.5856,
+      "defMultiplier": 25.043,
+      "goldCost": 1175100000,
+      "crystalCost": 159009
+    },
+    {
+      "level": 1362,
+      "atkMultiplier": 51.7209,
+      "hpMultiplier": 36.6299,
+      "defMultiplier": 25.0724,
+      "goldCost": 1180100000,
+      "crystalCost": 159509
+    },
+    {
+      "level": 1363,
+      "atkMultiplier": 51.7854,
+      "hpMultiplier": 36.6743,
+      "defMultiplier": 25.1017,
+      "goldCost": 1185100000,
+      "crystalCost": 160009
+    },
+    {
+      "level": 1364,
+      "atkMultiplier": 51.8499,
+      "hpMultiplier": 36.7186,
+      "defMultiplier": 25.1311,
+      "goldCost": 1190100000,
+      "crystalCost": 160509
+    },
+    {
+      "level": 1365,
+      "atkMultiplier": 51.9145,
+      "hpMultiplier": 36.763,
+      "defMultiplier": 25.1605,
+      "goldCost": 1195100000,
+      "crystalCost": 161009
+    },
+    {
+      "level": 1366,
+      "atkMultiplier": 51.9791,
+      "hpMultiplier": 36.8074,
+      "defMultiplier": 25.1899,
+      "goldCost": 1200100000,
+      "crystalCost": 161509
+    },
+    {
+      "level": 1367,
+      "atkMultiplier": 52.0438,
+      "hpMultiplier": 36.8519,
+      "defMultiplier": 25.2193,
+      "goldCost": 1205100000,
+      "crystalCost": 162009
+    },
+    {
+      "level": 1368,
+      "atkMultiplier": 52.1085,
+      "hpMultiplier": 36.8963,
+      "defMultiplier": 25.2488,
+      "goldCost": 1210100000,
+      "crystalCost": 162509
+    },
+    {
+      "level": 1369,
+      "atkMultiplier": 52.1732,
+      "hpMultiplier": 36.9408,
+      "defMultiplier": 25.2782,
+      "goldCost": 1215100000,
+      "crystalCost": 163009
+    },
+    {
+      "level": 1370,
+      "atkMultiplier": 52.238,
+      "hpMultiplier": 36.9853,
+      "defMultiplier": 25.3077,
+      "goldCost": 1220100000,
+      "crystalCost": 163509
+    },
+    {
+      "level": 1371,
+      "atkMultiplier": 52.3028,
+      "hpMultiplier": 37.0299,
+      "defMultiplier": 25.3372,
+      "goldCost": 1225100000,
+      "crystalCost": 164009
+    },
+    {
+      "level": 1372,
+      "atkMultiplier": 52.3677,
+      "hpMultiplier": 37.0745,
+      "defMultiplier": 25.3667,
+      "goldCost": 1230100000,
+      "crystalCost": 164509
+    },
+    {
+      "level": 1373,
+      "atkMultiplier": 52.4326,
+      "hpMultiplier": 37.1191,
+      "defMultiplier": 25.3962,
+      "goldCost": 1235100000,
+      "crystalCost": 165009
+    },
+    {
+      "level": 1374,
+      "atkMultiplier": 52.4975,
+      "hpMultiplier": 37.1637,
+      "defMultiplier": 25.4258,
+      "goldCost": 1240100000,
+      "crystalCost": 165509
+    },
+    {
+      "level": 1375,
+      "atkMultiplier": 52.5625,
+      "hpMultiplier": 37.2083,
+      "defMultiplier": 25.4554,
+      "goldCost": 1245100000,
+      "crystalCost": 166009
+    },
+    {
+      "level": 1376,
+      "atkMultiplier": 52.6275,
+      "hpMultiplier": 37.253,
+      "defMultiplier": 25.4849,
+      "goldCost": 1250100000,
+      "crystalCost": 166509
+    },
+    {
+      "level": 1377,
+      "atkMultiplier": 52.6926,
+      "hpMultiplier": 37.2977,
+      "defMultiplier": 25.5145,
+      "goldCost": 1255100000,
+      "crystalCost": 167009
+    },
+    {
+      "level": 1378,
+      "atkMultiplier": 52.7577,
+      "hpMultiplier": 37.3425,
+      "defMultiplier": 25.5441,
+      "goldCost": 1260100000,
+      "crystalCost": 167509
+    },
+    {
+      "level": 1379,
+      "atkMultiplier": 52.8228,
+      "hpMultiplier": 37.3872,
+      "defMultiplier": 25.5738,
+      "goldCost": 1265100000,
+      "crystalCost": 168009
+    },
+    {
+      "level": 1380,
+      "atkMultiplier": 52.888,
+      "hpMultiplier": 37.432,
+      "defMultiplier": 25.6034,
+      "goldCost": 1270100000,
+      "crystalCost": 168509
+    },
+    {
+      "level": 1381,
+      "atkMultiplier": 52.9532,
+      "hpMultiplier": 37.4768,
+      "defMultiplier": 25.6331,
+      "goldCost": 1275100000,
+      "crystalCost": 169009
+    },
+    {
+      "level": 1382,
+      "atkMultiplier": 53.0185,
+      "hpMultiplier": 37.5217,
+      "defMultiplier": 25.6628,
+      "goldCost": 1280100000,
+      "crystalCost": 169509
+    },
+    {
+      "level": 1383,
+      "atkMultiplier": 53.0838,
+      "hpMultiplier": 37.5665,
+      "defMultiplier": 25.6925,
+      "goldCost": 1285100000,
+      "crystalCost": 170009
+    },
+    {
+      "level": 1384,
+      "atkMultiplier": 53.1491,
+      "hpMultiplier": 37.6114,
+      "defMultiplier": 25.7222,
+      "goldCost": 1290100000,
+      "crystalCost": 170509
+    },
+    {
+      "level": 1385,
+      "atkMultiplier": 53.2145,
+      "hpMultiplier": 37.6563,
+      "defMultiplier": 25.7519,
+      "goldCost": 1295100000,
+      "crystalCost": 171009
+    },
+    {
+      "level": 1386,
+      "atkMultiplier": 53.2799,
+      "hpMultiplier": 37.7013,
+      "defMultiplier": 25.7817,
+      "goldCost": 1300100000,
+      "crystalCost": 171509
+    },
+    {
+      "level": 1387,
+      "atkMultiplier": 53.3454,
+      "hpMultiplier": 37.7463,
+      "defMultiplier": 25.8114,
+      "goldCost": 1305100000,
+      "crystalCost": 172009
+    },
+    {
+      "level": 1388,
+      "atkMultiplier": 53.4109,
+      "hpMultiplier": 37.7913,
+      "defMultiplier": 25.8412,
+      "goldCost": 1310100000,
+      "crystalCost": 172509
+    },
+    {
+      "level": 1389,
+      "atkMultiplier": 53.4764,
+      "hpMultiplier": 37.8363,
+      "defMultiplier": 25.871,
+      "goldCost": 1315100000,
+      "crystalCost": 173009
+    },
+    {
+      "level": 1390,
+      "atkMultiplier": 53.542,
+      "hpMultiplier": 37.8813,
+      "defMultiplier": 25.9009,
+      "goldCost": 1320100000,
+      "crystalCost": 173509
+    },
+    {
+      "level": 1391,
+      "atkMultiplier": 53.6076,
+      "hpMultiplier": 37.9264,
+      "defMultiplier": 25.9307,
+      "goldCost": 1325100000,
+      "crystalCost": 174009
+    },
+    {
+      "level": 1392,
+      "atkMultiplier": 53.6733,
+      "hpMultiplier": 37.9715,
+      "defMultiplier": 25.9605,
+      "goldCost": 1330100000,
+      "crystalCost": 174509
+    },
+    {
+      "level": 1393,
+      "atkMultiplier": 53.739,
+      "hpMultiplier": 38.0167,
+      "defMultiplier": 25.9904,
+      "goldCost": 1335100000,
+      "crystalCost": 175009
+    },
+    {
+      "level": 1394,
+      "atkMultiplier": 53.8047,
+      "hpMultiplier": 38.0618,
+      "defMultiplier": 26.0203,
+      "goldCost": 1340100000,
+      "crystalCost": 175509
+    },
+    {
+      "level": 1395,
+      "atkMultiplier": 53.8705,
+      "hpMultiplier": 38.107,
+      "defMultiplier": 26.0502,
+      "goldCost": 1345100000,
+      "crystalCost": 176009
+    },
+    {
+      "level": 1396,
+      "atkMultiplier": 53.9363,
+      "hpMultiplier": 38.1522,
+      "defMultiplier": 26.0801,
+      "goldCost": 1350100000,
+      "crystalCost": 176509
+    },
+    {
+      "level": 1397,
+      "atkMultiplier": 54.0022,
+      "hpMultiplier": 38.1975,
+      "defMultiplier": 26.1101,
+      "goldCost": 1355100000,
+      "crystalCost": 177009
+    },
+    {
+      "level": 1398,
+      "atkMultiplier": 54.0681,
+      "hpMultiplier": 38.2427,
+      "defMultiplier": 26.14,
+      "goldCost": 1360100000,
+      "crystalCost": 177509
+    },
+    {
+      "level": 1399,
+      "atkMultiplier": 54.134,
+      "hpMultiplier": 38.288,
+      "defMultiplier": 26.17,
+      "goldCost": 1365100000,
+      "crystalCost": 178009
+    },
+    {
+      "level": 1400,
+      "atkMultiplier": 54.2,
+      "hpMultiplier": 38.3333,
+      "defMultiplier": 26.2,
+      "goldCost": 1370100000,
+      "crystalCost": 178509
+    }
+  ],
+  "costFactors": {
+    "baseGoldCost": 1000,
+    "goldGrowthRate": 1,
+    "baseCrystalCost": 10,
+    "crystalGrowthRate": 1,
+    "thresholds": [
+      {
+        "fromLevel": 1,
+        "toLevel": 100,
+        "goldMultiplier": 1,
+        "crystalMultiplier": 1
+      },
+      {
+        "fromLevel": 101,
+        "toLevel": 300,
+        "goldMultiplier": 5,
+        "crystalMultiplier": 2
+      },
+      {
+        "fromLevel": 301,
+        "toLevel": 600,
+        "goldMultiplier": 30,
+        "crystalMultiplier": 10
+      },
+      {
+        "fromLevel": 601,
+        "toLevel": 900,
+        "goldMultiplier": 200,
+        "crystalMultiplier": 50
+      },
+      {
+        "fromLevel": 901,
+        "toLevel": 1200,
+        "goldMultiplier": 1000,
+        "crystalMultiplier": 200
+      },
+      {
+        "fromLevel": 1201,
+        "toLevel": 1400,
+        "goldMultiplier": 5000,
+        "crystalMultiplier": 500
+      }
+    ]
+  }
+}

--- a/src/types/equipment.ts
+++ b/src/types/equipment.ts
@@ -1,0 +1,176 @@
+/**
+ * Equipment tier quality levels, ordered from lowest to highest.
+ * Source: EQUIPMENT sheet, TIER column.
+ */
+export type WeaponTierName =
+  | 'Common'
+  | 'Uncommon'
+  | 'Rare'
+  | 'Epic'
+  | 'Legendary'
+  | 'Mythic'
+  | 'Transcendent';
+
+/**
+ * A weapon tier row from the EQUIPMENT sheet.
+ * Defines base stats and per-level scaling for each quality tier.
+ */
+export interface WeaponTier {
+  /** Sequential tier number (1 = Common … 7 = Transcendent) */
+  tier: number;
+  /** Human-readable tier name */
+  name: WeaponTierName;
+  /** Hex colour used to represent this tier in UI */
+  color: string;
+  /** Base attack power before any enhancement */
+  baseDamage: number;
+  /** Flat attack added per enhancement level */
+  damagePerLevel: number;
+  /** Base HP contribution before any enhancement */
+  baseHp: number;
+  /** Flat HP added per enhancement level */
+  hpPerLevel: number;
+  /** Gold cost to craft / obtain (before level multiplier) */
+  craftCost: number;
+  /** Bonus multiplier applied to all stats for this tier */
+  tierMultiplier: number;
+}
+
+/**
+ * Elemental affinity of a soul weapon.
+ */
+export type SoulElement = 'Fire' | 'Water' | 'Earth' | 'Wind' | 'Light' | 'Dark';
+
+/**
+ * A soul weapon row from the SOUL_WEAPONS sheet.
+ */
+export interface SoulWeapon {
+  /** Unique identifier (snake_case) */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Elemental affinity */
+  element: SoulElement;
+  /** Quality tier of this soul weapon */
+  tier: WeaponTierName;
+  /** Base attack damage */
+  baseDamage: number;
+  /** Critical hit rate bonus (percentage points, e.g. 5 = +5%) */
+  critRateBonus: number;
+  /** Critical hit damage bonus (percentage points, e.g. 20 = +20%) */
+  critDmgBonus: number;
+  /** Elemental damage bonus when attacker matches element (percentage) */
+  elementBonus: number;
+  /** Short description of the unique special effect */
+  specialEffect: string;
+  /** How to acquire this soul weapon */
+  acquisitionMethod: string;
+}
+
+/**
+ * Equipment slot an accessory occupies.
+ */
+export type AccessorySlot = 'Ring' | 'Necklace' | 'Belt' | 'Earring' | 'Bracelet';
+
+/**
+ * Stat type boosted by an accessory.
+ */
+export type AccessoryBonusType =
+  | 'ATK'
+  | 'HP'
+  | 'DEF'
+  | 'Crit%'
+  | 'CritDMG'
+  | 'Gold'
+  | 'EXP'
+  | 'Dodge'
+  | 'Accuracy';
+
+/**
+ * A single accessory row from the ACCESSORIES sheet.
+ */
+export interface Accessory {
+  /** Unique identifier (snake_case) */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Equipment slot this accessory fills */
+  slot: AccessorySlot;
+  /** Quality tier */
+  tier: WeaponTierName;
+  /** Stat this accessory boosts */
+  bonusType: AccessoryBonusType;
+  /**
+   * Bonus amount.
+   * Flat value when isPercent is false; percentage points when true.
+   */
+  bonusValue: number;
+  /** Whether bonusValue is a percentage (true) or a flat amount (false) */
+  isPercent: boolean;
+  /** Gold cost to craft this accessory */
+  craftCost: number;
+}
+
+/**
+ * One row of the LEVEL_MULTIPLIERS sheet (1 400 rows, levels 1–1400).
+ * Multipliers are applied to base stats at each enhancement level.
+ */
+export interface LevelMultiplier {
+  /** Enhancement level (1–1400) */
+  level: number;
+  /** Attack multiplier at this level (e.g. 2.5 = 2.5× base ATK) */
+  atkMultiplier: number;
+  /** HP multiplier at this level */
+  hpMultiplier: number;
+  /** Defense multiplier at this level */
+  defMultiplier: number;
+  /** Gold required to enhance from (level − 1) to this level */
+  goldCost: number;
+  /** Crystals required to enhance from (level − 1) to this level */
+  crystalCost: number;
+}
+
+/**
+ * Threshold band inside the cost-factor table.
+ * Within a band, costs are scaled by a fixed multiplier on top of the
+ * per-level gold / crystal growth rates.
+ */
+export interface CostThreshold {
+  /** First enhancement level in this band (inclusive) */
+  fromLevel: number;
+  /** Last enhancement level in this band (inclusive) */
+  toLevel: number;
+  /** Extra gold multiplier applied within this band */
+  goldMultiplier: number;
+  /** Extra crystal multiplier applied within this band */
+  crystalMultiplier: number;
+}
+
+/**
+ * Global scaling parameters from the COST_FACTORS sheet.
+ * Used together with LevelMultiplier.goldCost / crystalCost for exact costs.
+ */
+export interface CostFactors {
+  /** Gold cost at enhancement level 1 */
+  baseGoldCost: number;
+  /** Per-level multiplicative growth rate for gold (e.g. 1.05 = +5% / level) */
+  goldGrowthRate: number;
+  /** Crystal cost at enhancement level 1 */
+  baseCrystalCost: number;
+  /** Per-level multiplicative growth rate for crystals */
+  crystalGrowthRate: number;
+  /** Level bands where cost scaling steps up */
+  thresholds: CostThreshold[];
+}
+
+/**
+ * Root shape of the EQUIPMENT_DATA JSON file.
+ */
+export interface EquipmentData {
+  weaponTiers: WeaponTier[];
+  soulWeapons: SoulWeapon[];
+  accessories: Accessory[];
+  /** Sorted ascending by level; contains entries for levels 1–1400 */
+  levelMultipliers: LevelMultiplier[];
+  costFactors: CostFactors;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,17 @@ export type {
   AppearanceBonusTotals,
   AppearanceState,
 } from './appearance';
+
+export type {
+  WeaponTierName,
+  WeaponTier,
+  SoulElement,
+  SoulWeapon,
+  AccessorySlot,
+  AccessoryBonusType,
+  Accessory,
+  LevelMultiplier,
+  CostThreshold,
+  CostFactors,
+  EquipmentData,
+} from './equipment';


### PR DESCRIPTION
## Summary

- **`src/data/equipment.json`** — Full equipment dataset (11 855 lines):
  - 7 weapon tiers (Common → Transcendent) with base damage, HP, craft cost, and tier multipliers
  - 12 soul weapons (2 per element: Fire/Water/Earth/Wind/Light/Dark) with crit bonuses, elemental bonuses, and special effects
  - 38 accessories across 5 slots (Ring, Necklace, Belt, Earring, Bracelet) and all quality tiers
  - 1 400 level multiplier rows with pre-computed ATK/HP/DEF multipliers and piecewise-linear gold & crystal upgrade costs
  - 6 cost-factor threshold bands (levels 1–100, 101–300, 301–600, 601–900, 901–1200, 1201–1400)

- **`src/types/equipment.ts`** — TypeScript interfaces for all equipment shapes (`WeaponTier`, `SoulWeapon`, `Accessory`, `LevelMultiplier`, `CostFactors`, `EquipmentData`, and supporting union types)

- **`src/types/index.ts`** — Re-exports all new equipment types alongside existing appearance types

## Test plan

- [ ] `tsc --noEmit` passes with no type errors
- [ ] `equipment.json` parses without error and `levelMultipliers` has exactly 1400 entries
- [ ] Spot-check multipliers: L=1 atk≈1.01×, L=100≈2.2×, L=700≈17.8×, L=1400≈54.2×
- [ ] Spot-check costs: L=1 gold=1000, L=1400 gold=1,370,100,000 (safe integer, no overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)